### PR TITLE
feat: zero-project mode — run tests without npm install

### DIFF
--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && cp src/zero-project-register.mjs src/zero-project-resolver.mjs dist/",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/runner/src/executor.ts
+++ b/packages/runner/src/executor.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { readFile, writeFile, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, join } from "node:path";
 import { createRequire } from "node:module";
 import type { ApiTrace, GlubeanAction, GlubeanEvent } from "@glubean/sdk";
 import type { SharedRunConfig } from "./config.js";
@@ -290,9 +291,43 @@ export class TestExecutor {
       env["NODE_OPTIONS"] = nodeOptions.join(" ");
     }
 
+    // ── Zero-project mode ────────────────────────────────────────────────────
+    // If the user's cwd has no node_modules/@glubean/sdk, inject a custom
+    // ESM resolver so `import { test } from "@glubean/sdk"` resolves from
+    // the runner's own dependencies. Also create a temporary package.json
+    // with "type":"module" if none exists (so .js files are treated as ESM).
+    const cwd = this.options.cwd || process.cwd();
+    const zeroProject = !existsSync(join(cwd, "node_modules", "@glubean", "sdk"));
+    let tempPackageJson = false;
+
+    const tsxArgs: string[] = [];
+
+    if (zeroProject) {
+      const registerPath = resolve(__dirname, "zero-project-register.mjs");
+      tsxArgs.push("--import", registerPath);
+
+      // Point resolver to the node_modules that contains @glubean/sdk.
+      // import.meta.resolve works for ESM-only packages; returns a file:// URL.
+      // Walk up: dist/index.js → dist → @glubean/sdk → @glubean → node_modules
+      const sdkUrl = import.meta.resolve("@glubean/sdk");
+      const sdkEntry = fileURLToPath(sdkUrl); // .../dist/index.js
+      env["GLUBEAN_VENDORED_ROOT"] = resolve(dirname(sdkEntry), "../../..");
+
+      // Ensure .js files are treated as ESM
+      if (!existsSync(join(cwd, "package.json"))) {
+        try {
+          const { writeFileSync } = await import("node:fs");
+          writeFileSync(join(cwd, "package.json"), '{"type":"module"}\n');
+          tempPackageJson = true;
+        } catch {
+          // Non-critical — .mjs files still work
+        }
+      }
+    }
+
     // Spawn tsx subprocess via node
-    const child = spawn("node", [resolveTsxPath(), ...args], {
-      cwd: this.options.cwd,
+    const child = spawn("node", [resolveTsxPath(), ...tsxArgs, ...args], {
+      cwd,
       env,
       stdio: ["pipe", "pipe", inspectBrk ? "inherit" : "pipe"],
     });
@@ -402,6 +437,17 @@ export class TestExecutor {
             type: "error",
             message: `Process exited with code ${code}${signal ? ` (signal: ${signal})` : ""}`,
           });
+        }
+      }
+
+      // Clean up temporary package.json created for zero-project mode
+      if (tempPackageJson) {
+        try {
+          import("node:fs").then(({ unlinkSync }) => {
+            unlinkSync(join(cwd, "package.json"));
+          }).catch(() => {});
+        } catch {
+          // Non-critical
         }
       }
 

--- a/packages/runner/src/zero-project-register.mjs
+++ b/packages/runner/src/zero-project-register.mjs
@@ -1,0 +1,13 @@
+/**
+ * Registration entry point for the zero-project ESM resolver.
+ *
+ * Used via: tsx --import <this-file> harness.js ...
+ *
+ * Registers the custom resolver hook so that @glubean/* imports
+ * can be resolved from the runner's vendored node_modules even when
+ * the user has no node_modules in their working directory.
+ */
+
+import { register } from "node:module";
+
+register(new URL("./zero-project-resolver.mjs", import.meta.url));

--- a/packages/runner/src/zero-project-resolver.mjs
+++ b/packages/runner/src/zero-project-resolver.mjs
@@ -1,0 +1,28 @@
+/**
+ * Zero-project ESM resolver for @glubean/* packages.
+ *
+ * When a test file lives outside a project (no node_modules), this resolver
+ * intercepts `@glubean/*` imports and resolves them from the runner's own
+ * node_modules — so users can write a single .test.js file and run it
+ * without `npm install`.
+ *
+ * Injected by TestExecutor via `--import` when zero-project mode is active.
+ *
+ * The GLUBEAN_VENDORED_ROOT env var is set by the executor to point to
+ * the directory containing @glubean/sdk (the runner's parent node_modules).
+ */
+
+const vendoredRoot = process.env["GLUBEAN_VENDORED_ROOT"];
+
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    // Fallback: resolve @glubean/* from the runner's own node_modules
+    if (vendoredRoot && specifier.startsWith("@glubean/")) {
+      const parentURL = `file://${vendoredRoot}/.zero-project-resolver`;
+      return nextResolve(specifier, { ...context, parentURL });
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- When user's directory has no `node_modules/@glubean/sdk`, the executor automatically injects a custom ESM resolver via `--import` that resolves `@glubean/*` imports from the runner's own dependencies
- Creates temporary `package.json` with `"type":"module"` for `.js` files (cleaned up after execution)
- Users can write a single `.test.js` file anywhere and run it — no project setup needed

## How it works
1. `TestExecutor.run()` checks if `node_modules/@glubean/sdk` exists in cwd
2. If not → injects `--import zero-project-register.mjs` into tsx args
3. The custom resolver intercepts failed `@glubean/*` imports and re-resolves from the runner's own node_modules
4. Temp `package.json` ensures `.js` files are treated as ESM

## Test plan
- [x] Verified: bare `.test.js` file in empty directory runs successfully through TestExecutor
- [x] Verified: all 139 existing runner tests still pass
- [x] Verified: temp package.json is cleaned up after execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)