### PR TITLE
feat(mcp): SDK / runner version-skew probe (Plan 3)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -986,10 +986,17 @@ export async function runCommand(
   }> = [];
   let success = false;
   let errorMsg: string | undefined;
+  let errorStack: string | undefined;
+  let errorReason: string | undefined;
+  let errorMissingPath: string | undefined;
+  let errorSuggestions: string[] | undefined;
   let peakMemoryMB: string | undefined;
   let stepAssertionCount = 0;
   let stepTraceLines: string[] = [];
   let testStarted = false;
+  // Plan 1 AC5: dedupe warning messages per session so the same warning
+  // doesn't repeat across session setup + each file's run() call.
+  const emittedWarnings = new Set<string>();
 
   const addLogEntry = (
     type: LogEntry["type"],
@@ -1090,7 +1097,33 @@ export async function runCommand(
     }
 
     if (errorMsg) {
-      console.log(`      ${colors.red}Error: ${errorMsg}${colors.reset}`);
+      if (errorReason === "test_file_missing" && errorMissingPath) {
+        console.log(
+          `      ${colors.red}✗ Test file not found: ${errorMissingPath}${colors.reset}`,
+        );
+        if (errorSuggestions && errorSuggestions.length > 0) {
+          console.log(`        ${colors.dim}Did you mean:${colors.reset}`);
+          for (const s of errorSuggestions) {
+            console.log(`          ${s}`);
+          }
+        }
+      } else {
+        console.log(`      ${colors.red}Error: ${errorMsg}${colors.reset}`);
+        if (errorStack) {
+          const lines = errorStack.split("\n").slice(1);
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            const isFramework =
+              trimmed.includes("/node_modules/") ||
+              trimmed.includes("/@glubean/runner/") ||
+              trimmed.includes("internal/modules/");
+            console.log(
+              `        ${isFramework ? colors.dim : colors.reset}${trimmed}${colors.reset}`,
+            );
+          }
+        }
+      }
     }
   };
 
@@ -1190,6 +1223,16 @@ export async function runCommand(
           console.log(
             `  ${colors.dim}[session] ${se.message}${colors.reset}`,
           );
+        } else if (se.type === "warning") {
+          // Plan 1 AC5: render runner-fallback warnings emitted during
+          // session setup. Only dedupe runner diagnostics (those carry a
+          // `code` field — see ExecutionEvent.warning schema); user-emitted
+          // ctx.warn(false, ...) warnings have no code and pass through.
+          const isRunnerDiag = !!(se as { code?: string }).code;
+          if (!isRunnerDiag || !emittedWarnings.has(se.message)) {
+            if (isRunnerDiag) emittedWarnings.add(se.message);
+            console.log(`  ${colors.yellow}⚠ ${se.message}${colors.reset}`);
+          }
         }
         break;
       }
@@ -1278,6 +1321,10 @@ export async function runCommand(
             assertions = [];
             success = false;
             errorMsg = undefined;
+            errorStack = undefined;
+            errorReason = undefined;
+            errorMissingPath = undefined;
+            errorSuggestions = undefined;
             peakMemoryMB = undefined;
             stepAssertionCount = 0;
             stepTraceLines = [];
@@ -1301,6 +1348,10 @@ export async function runCommand(
             success = event.status === "completed";
             if (event.error) {
               errorMsg = event.error;
+              errorStack = event.stack;
+              errorReason = event.reason;
+              errorMissingPath = event.missingPath;
+              errorSuggestions = event.suggestions;
               addLogEntry("error", event.error);
             }
             if (event.peakMemoryMB) peakMemoryMB = event.peakMemoryMB;
@@ -1309,7 +1360,13 @@ export async function runCommand(
 
           case "error":
             success = false;
-            if (!errorMsg) errorMsg = event.message;
+            if (!errorMsg) {
+              errorMsg = event.message;
+              errorStack = event.stack;
+              errorReason = event.reason;
+              errorMissingPath = event.missingPath;
+              errorSuggestions = event.suggestions;
+            }
             addLogEntry("error", event.message);
             break;
 
@@ -1474,9 +1531,17 @@ export async function runCommand(
 
           case "warning": {
             const warnIcon = event.condition ? `${colors.green}✓${colors.reset}` : `${colors.yellow}⚠${colors.reset}`;
-            console.log(
-              `      ${warnIcon} ${colors.yellow}${event.message}${colors.reset}`,
-            );
+            // Plan 1 AC5: dedupe runner-fallback / protocol-min warnings
+            // (carry a `code` field — see ExecutionEvent.warning schema).
+            // User-emitted ctx.warn(false, ...) warnings have no code and
+            // pass through every time so test authors can see them repeat.
+            const isRunnerDiag = !!event.code;
+            if (!isRunnerDiag || !emittedWarnings.has(event.message)) {
+              if (isRunnerDiag) emittedWarnings.add(event.message);
+              console.log(
+                `      ${warnIcon} ${colors.yellow}${event.message}${colors.reset}`,
+              );
+            }
             break;
           }
 
@@ -1506,9 +1571,37 @@ export async function runCommand(
         // mid-test or emitted no start event, promote the leftover state
         // to a visible failure row.
         if (!testStarted && errorMsg) {
-          console.log(
-            `  ${colors.red}✗ ${errorMsg}${colors.reset}`,
-          );
+          // Plan 4: rich render for orphan-error case (no leading start event,
+          // e.g. harness died during userModule import).
+          if (errorReason === "test_file_missing" && errorMissingPath) {
+            console.log(
+              `  ${colors.red}✗ Test file not found: ${errorMissingPath}${colors.reset}`,
+            );
+            if (errorSuggestions && errorSuggestions.length > 0) {
+              console.log(`    ${colors.dim}Did you mean:${colors.reset}`);
+              for (const s of errorSuggestions) {
+                console.log(`      ${s}`);
+              }
+            }
+          } else {
+            console.log(
+              `  ${colors.red}✗ ${errorMsg}${colors.reset}`,
+            );
+            if (errorStack) {
+              const lines = errorStack.split("\n").slice(1);
+              for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                const isFramework =
+                  trimmed.includes("/node_modules/") ||
+                  trimmed.includes("/@glubean/runner/") ||
+                  trimmed.includes("internal/modules/");
+                console.log(
+                  `    ${isFramework ? colors.dim : colors.reset}${trimmed}${colors.reset}`,
+                );
+              }
+            }
+          }
           failed++;
         }
         if (testStarted) {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,13 +27,13 @@
   "dependencies": {
     "@glubean/runner": "workspace:*",
     "@glubean/scanner": "workspace:*",
+    "@glubean/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "dotenv": "^16.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@glubean/graphql": "workspace:*",
-    "@glubean/sdk": "workspace:*",
     "@types/node": "^22.0.0"
   },
   "repository": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -779,6 +779,8 @@ export async function runLocalTestsFromFile(args: {
   results: LocalRunResult[];
   summary: { total: number; passed: number; failed: number };
   error?: string;
+  /** Runner-fallback or protocol warnings emitted by the executor. (Plan 1 AC6) */
+  warnings?: string[];
 }> {
   const absolutePath = resolve(args.filePath);
   const testDir = dirname(absolutePath);
@@ -960,6 +962,10 @@ export async function runLocalTestsFromFile(args: {
   // "no tests" success). Populated by `run:failed` / `bootstrap:failed` /
   // `session:setup:failed` events from the facade.
   let orchestrationError: string | undefined;
+  // Plan 1 AC6: collect runner-fallback / protocol warnings emitted at the
+  // start of every TestExecutor.run() call. Deduped by message so the same
+  // warning doesn't repeat across session setup + each file's invocation.
+  const warningSet = new Set<string>();
 
   for await (const evt of runner.run()) {
     // Surface non-file failure events so callers can distinguish them from
@@ -1062,6 +1068,17 @@ export async function runLocalTestsFromFile(args: {
         if (acc && !acc.errorMessage) acc.errorMessage = event.message;
         break;
       }
+      case "warning": {
+        // Plan 1 AC6: collect runner-fallback / protocol-min warnings.
+        // Discriminate by the `code` field (set by executor diagnostics
+        // only — user-emitted ctx.warn(false, "...") warnings have no
+        // code and are intentionally NOT surfaced at the run level since
+        // they're per-test concerns, not project-wide).
+        if (event.code && event.message) {
+          warningSet.add(event.message);
+        }
+        break;
+      }
     }
   }
 
@@ -1082,6 +1099,8 @@ export async function runLocalTestsFromFile(args: {
   const passed = results.filter((r) => r.success).length;
   const failed = results.filter((r) => !r.success).length;
 
+  const warningsArr = [...warningSet];
+
   return {
     fileUrl,
     projectRoot,
@@ -1090,6 +1109,7 @@ export async function runLocalTestsFromFile(args: {
     results,
     summary: { total: results.length, passed, failed },
     ...(orchestrationError !== undefined && { error: orchestrationError }),
+    ...(warningsArr.length > 0 && { warnings: warningsArr }),
   };
 }
 
@@ -1250,6 +1270,12 @@ server.registerTool(
     };
     if (result.error) {
       safe.error = result.error;
+    }
+    // Plan 1 AC6: forward runner-fallback / protocol warnings to the agent
+    // so it can surface version-skew misconfigurations instead of leaving
+    // the user with mysterious "configure() values" errors.
+    if (result.warnings && result.warnings.length > 0) {
+      safe.warnings = result.warnings;
     }
 
     lastLocalRunSnapshot = {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -38,6 +38,7 @@ import {
 } from "@glubean/scanner";
 import type { BundleMetadata, ExportMeta, FileMeta, ScanResult } from "@glubean/scanner";
 import { MCP_PACKAGE_VERSION, DEFAULT_GENERATED_BY } from "./version.js";
+import { checkSdkCompat, type CompatResult } from "./version-compat.js";
 
 type Vars = Record<string, string>;
 const METADATA_SCHEMA_VERSION = "1";
@@ -781,10 +782,44 @@ export async function runLocalTestsFromFile(args: {
   error?: string;
   /** Runner-fallback or protocol warnings emitted by the executor. (Plan 1 AC6) */
   warnings?: string[];
+  /**
+   * SDK / runner version compat probe result (Plan 3).
+   * Always populated. When `ok: false`, tests were NOT run because we
+   * detected a dual-package hazard that would have produced misleading
+   * errors. See `versionInfo.message` for the install command.
+   */
+  versionInfo?: CompatResult;
 }> {
   const absolutePath = resolve(args.filePath);
   const testDir = dirname(absolutePath);
   const projectRoot = await findProjectRoot(testDir);
+
+  // Plan 3: SDK / runner version-skew probe. Fires BEFORE we spawn the
+  // harness so an unrecoverable dual-package hazard (project has @glubean/sdk
+  // pinned at a different version + no @glubean/runner installed → Plan 1's
+  // fallback path can't produce a hazard-free spawn) is reported as a
+  // structured `sdk_version_skew` error instead of a misleading runtime
+  // error inside the test. Plan 1's runner fix transparently handles the
+  // common case (project-local runner present); this probe only short-
+  // circuits the residual sdk-only scenario.
+  const versionInfo = checkSdkCompat(projectRoot);
+  if (!versionInfo.ok) {
+    const fileUrl = pathToFileURL(absolutePath).href;
+    return {
+      fileUrl,
+      projectRoot,
+      vars: {},
+      secrets: {},
+      results: [],
+      summary: { total: 0, passed: 0, failed: 0 },
+      // Failure class differentiates the two `ok: false` paths in checkSdkCompat:
+      //   - "sdk_version_skew" — recoverable; user installs @glubean/runner
+      //   - "mcp_packaging_bug" — MCP itself broken; file an issue
+      error: versionInfo.failureCode ?? "sdk_version_skew",
+      versionInfo,
+    };
+  }
+
   const traceConfig = await loadMcpTraceConfig(projectRoot);
 
   const envPath = await resolveEnvPath(projectRoot, args.envFile);
@@ -822,6 +857,7 @@ export async function runLocalTestsFromFile(args: {
         ? "No tests discovered in file. Check that exports use test() or contract.http.with() from @glubean/sdk."
         : `No tests matched filter "${args.filter}". Available: ${tests.map((t) => t.id).join(", ")}`,
       ...(discoveryErrors && discoveryErrors.length > 0 ? { importErrors: discoveryErrors } : {}),
+      versionInfo,
     };
   }
 
@@ -883,6 +919,7 @@ export async function runLocalTestsFromFile(args: {
         error:
           "inputJson and bootstrapInput are mutually exclusive. " +
           "Per attachment-model §5.1: explicit input bypasses the overlay, so bootstrap params would be ignored. Pick one channel per run.",
+        versionInfo,
       };
     }
     if (selected.length !== 1) {
@@ -900,6 +937,7 @@ export async function runLocalTestsFromFile(args: {
             ? `: ${selected.map((t) => t.id).slice(0, 10).join(", ")}`
             : "") +
           ".",
+        versionInfo,
       };
     }
     const targetTestId = selected[0]!.id;
@@ -1110,6 +1148,7 @@ export async function runLocalTestsFromFile(args: {
     summary: { total: results.length, passed, failed },
     ...(orchestrationError !== undefined && { error: orchestrationError }),
     ...(warningsArr.length > 0 && { warnings: warningsArr }),
+    versionInfo,
   };
 }
 
@@ -1276,6 +1315,12 @@ server.registerTool(
     // the user with mysterious "configure() values" errors.
     if (result.warnings && result.warnings.length > 0) {
       safe.warnings = result.warnings;
+    }
+    // Plan 3: forward structured compat info. Always include — even when
+    // tests ran successfully — so the agent has full SDK/runner version
+    // context if it wants to render it.
+    if (result.versionInfo) {
+      safe.versionInfo = result.versionInfo;
     }
 
     lastLocalRunSnapshot = {

--- a/packages/mcp/src/version-compat.ts
+++ b/packages/mcp/src/version-compat.ts
@@ -1,0 +1,210 @@
+/**
+ * SDK / runner version compat probe for the MCP server.
+ *
+ * Companion to Plan 1's project-local runner resolution. Plan 1 transparently
+ * routes spawn-time SDK identity through the project-local runner when one is
+ * installed. When NO project-local runner is installed (sdk-only projects),
+ * Plan 1 falls back to bundled and emits a `runner_fallback_no_project`
+ * warning — but the dual-package hazard still reproduces because the bundled
+ * harness's `@glubean/sdk` won't match user code's `@glubean/sdk`.
+ *
+ * This module's job: detect that scenario at MCP tool entry time, BEFORE we
+ * spawn the harness, and return a structured `sdk_version_skew` error to the
+ * agent so it surfaces an actionable install command instead of the user
+ * hitting the misleading "configure() values can only be accessed..." error.
+ *
+ * Discriminator: this probe is MCP-specific because (a) MCP responses go to
+ * an LLM agent who needs structured `versionInfo`, not a stack trace; (b)
+ * `npx -y @glubean/mcp@latest` causes silent version drift via the npm cache
+ * TTL — users don't pin MCP the way they pin CLI.
+ */
+
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+
+export interface CompatResult {
+  ok: boolean;
+  /**
+   * Differentiates failure modes when `ok: false`:
+   *   - "sdk_version_skew" — project pins @glubean/sdk at a realpath
+   *     different from bundled AND no project @glubean/runner is
+   *     installed. The dual-package hazard would reproduce. Recoverable
+   *     by `npm i -D @glubean/runner`.
+   *   - "mcp_packaging_bug" — MCP process can't resolve its own bundled
+   *     @glubean/sdk. Not the user's fault — file an issue against MCP.
+   * Omitted when `ok: true`.
+   */
+  failureCode?: "sdk_version_skew" | "mcp_packaging_bug";
+  projectSdkVersion?: string;
+  bundledSdkVersion: string;
+  projectRunnerInstalled: boolean;
+  projectRunnerVersion?: string;
+  bundledRunnerVersion?: string;
+  message?: string;
+}
+
+/**
+ * Walk up from a starting file looking for a package.json whose `name` field
+ * matches `expectedName`. Layout-independent — mirrors the helper in
+ * `@glubean/runner`'s executor.ts so MCP's probe survives the same bundler
+ * topologies. Returns the realpath of the package root.
+ */
+function findPackageRoot(startFile: string, expectedName: string): string | undefined {
+  let dir = dirname(startFile);
+  for (let i = 0; i < 16; i++) {
+    const candidate = resolve(dir, "package.json");
+    if (existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, "utf-8"));
+        if (pkg?.name === expectedName) {
+          try {
+            return realpathSync(dir);
+          } catch {
+            return dir;
+          }
+        }
+      } catch {
+        // continue walking — corrupt / non-json
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+  return undefined;
+}
+
+interface PkgInfo {
+  pkgDir: string;  // realpath of package root
+  version: string;
+}
+
+/**
+ * Resolve a package's main entry, then walk up to its package.json by name.
+ * Uses a cwd-rooted createRequire to avoid the workspace self-reference trap
+ * (see Plan 1 §3.1 for context). Returns undefined when not resolvable.
+ */
+function probePkg(name: string, projectCwd?: string): PkgInfo | undefined {
+  try {
+    const stubPath = projectCwd
+      ? resolve(projectCwd, "__glubean_compat_stub__.js")
+      : resolve(dirname(new URL(import.meta.url).pathname), "__bundled_stub__.js");
+    const req = createRequire(stubPath);
+    const mainEntry = req.resolve(name);
+    const pkgDir = findPackageRoot(mainEntry, name);
+    if (!pkgDir) return undefined;
+    const pkg = JSON.parse(readFileSync(resolve(pkgDir, "package.json"), "utf-8"));
+    return { pkgDir, version: pkg.version };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe the SDK + runner identities of the running MCP process and the
+ * caller's project. Returns `ok: false` only when the hazard is real:
+ * project has its own @glubean/sdk, the realpath differs from MCP's
+ * bundled SDK, AND project has no @glubean/runner installed (so Plan 1's
+ * project-local resolution would fall back to bundled).
+ *
+ * Every other case (no project SDK at all / matching SDK / project has
+ * runner) returns ok with structured metadata so the agent has full context.
+ */
+export function checkSdkCompat(projectRoot: string): CompatResult {
+  const bundledSdk = probePkg("@glubean/sdk");
+  const bundledRunner = probePkg("@glubean/runner");
+
+  if (!bundledSdk) {
+    return {
+      ok: false,
+      failureCode: "mcp_packaging_bug",
+      bundledSdkVersion: "<unresolved>",
+      projectRunnerInstalled: false,
+      message:
+        `@glubean/mcp is missing its runtime dependency on @glubean/sdk. ` +
+        `This is a packaging bug — please file an issue.`,
+    };
+  }
+
+  const projectSdk = probePkg("@glubean/sdk", projectRoot);
+  const projectRunner = probePkg("@glubean/runner", projectRoot);
+  const projectRunnerInstalled = projectRunner !== undefined;
+
+  if (!projectSdk) {
+    return {
+      ok: true,
+      bundledSdkVersion: bundledSdk.version,
+      bundledRunnerVersion: bundledRunner?.version,
+      projectRunnerInstalled,
+      projectRunnerVersion: projectRunner?.version,
+    };
+  }
+
+  if (projectSdk.pkgDir === bundledSdk.pkgDir) {
+    return {
+      ok: true,
+      projectSdkVersion: projectSdk.version,
+      bundledSdkVersion: bundledSdk.version,
+      bundledRunnerVersion: bundledRunner?.version,
+      projectRunnerInstalled,
+      projectRunnerVersion: projectRunner?.version,
+    };
+  }
+
+  if (projectRunnerInstalled && projectRunner) {
+    // Partial-upgrade hazard guard: project's @glubean/runner may have
+    // nested its OWN @glubean/sdk in its private node_modules (npm/pnpm
+    // sometimes leaves a nested copy when versions can't dedup). In that
+    // case the harness loads the runner's nested SDK while user test code
+    // loads project's direct SDK → different realpaths → dual-package
+    // hazard reproduces despite Plan 1's project-local runner resolution.
+    //
+    // Verify the runner's resolved SDK realpath matches the project's
+    // direct SDK realpath. If not, this is a real skew worth reporting.
+    const runnerNestedSdk = probePkg("@glubean/sdk", projectRunner.pkgDir);
+    if (runnerNestedSdk && runnerNestedSdk.pkgDir !== projectSdk.pkgDir) {
+      return {
+        ok: false,
+        failureCode: "sdk_version_skew",
+        projectSdkVersion: projectSdk.version,
+        bundledSdkVersion: bundledSdk.version,
+        bundledRunnerVersion: bundledRunner?.version,
+        projectRunnerInstalled: true,
+        projectRunnerVersion: projectRunner.version,
+        message:
+          `Project pins @glubean/sdk ${projectSdk.version} at ${projectSdk.pkgDir}, ` +
+          `but @glubean/runner ${projectRunner.version} resolves its own nested ` +
+          `@glubean/sdk ${runnerNestedSdk.version} at ${runnerNestedSdk.pkgDir}. ` +
+          `These are different module instances; tests will fail with a misleading ` +
+          `"configure() values can only be accessed during test execution" error. ` +
+          `Fix: align versions — e.g. \`npm dedupe\`, or update @glubean/runner to a ` +
+          `version that uses your pinned @glubean/sdk.`,
+      };
+    }
+
+    return {
+      ok: true,
+      projectSdkVersion: projectSdk.version,
+      bundledSdkVersion: bundledSdk.version,
+      bundledRunnerVersion: bundledRunner?.version,
+      projectRunnerInstalled: true,
+      projectRunnerVersion: projectRunner.version,
+    };
+  }
+
+  return {
+    ok: false,
+    failureCode: "sdk_version_skew",
+    projectSdkVersion: projectSdk.version,
+    bundledSdkVersion: bundledSdk.version,
+    bundledRunnerVersion: bundledRunner?.version,
+    projectRunnerInstalled: false,
+    message:
+      `Project pins @glubean/sdk ${projectSdk.version} but has no @glubean/runner installed; ` +
+      `MCP is using its bundled @glubean/runner${bundledRunner ? ` ${bundledRunner.version}` : ""} ` +
+      `+ @glubean/sdk ${bundledSdk.version}. These are different module instances; tests will fail ` +
+      `with a misleading "configure() values can only be accessed during test execution" error. ` +
+      `Fix: run "npm i -D @glubean/runner@${bundledRunner?.version ?? bundledSdk.version}" in the project.`,
+  };
+}

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -2,6 +2,8 @@
   "name": "@glubean/runner",
   "version": "0.2.6",
   "type": "module",
+  "glubeanRunnerProtocol": "1",
+  "glubeanRunnerProtocolMinimum": "1",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/runner/src/executor.ts
+++ b/packages/runner/src/executor.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync, unlinkSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, unlinkSync, readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { readFile, writeFile, rm } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve, join } from "node:path";
@@ -12,6 +12,239 @@ import { discoverSessionFile, createContextWithSession } from "./orchestrator.js
 
 const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_TIMEOUT_MS = 30000;
+
+// ── Project-local runner resolution (Plan 1) ────────────────────────────────
+
+/**
+ * Walk up from a starting file path looking for the first package.json
+ * whose `name` field matches `expectedName`. Layout-independent — works
+ * regardless of dist/ depth.
+ *
+ * Returns the realpath of the package root, or undefined if not found.
+ */
+function findPackageRoot(startFile: string, expectedName: string): string | undefined {
+  let dir = dirname(startFile);
+  for (let i = 0; i < 16; i++) {
+    const candidate = resolve(dir, "package.json");
+    if (existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, "utf-8"));
+        if (pkg?.name === expectedName) {
+          try {
+            return realpathSync(dir);
+          } catch {
+            return dir;
+          }
+        }
+      } catch {
+        // corrupt / non-json; keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Compare two version strings (numeric major.minor.patch). Returns true
+ * if `a < b`. Tolerant of missing fields and non-numeric tails.
+ */
+function semverLt(a: string, b: string): boolean {
+  const parse = (s: string) =>
+    s.split(/[.\-+]/).slice(0, 3).map((p) => parseInt(p, 10) || 0);
+  const [aMajor, aMinor, aPatch] = parse(a);
+  const [bMajor, bMinor, bPatch] = parse(b);
+  if (aMajor !== bMajor) return aMajor < bMajor;
+  if (aMinor !== bMinor) return aMinor < bMinor;
+  return aPatch < bPatch;
+}
+
+/** Diagnostic warning emitted by the executor's runner resolver. */
+interface RunnerWarning {
+  /** Human-readable message. */
+  message: string;
+  /** Stable code for filtering / consumer dedupe. */
+  code: "runner_fallback_no_project" | "runner_fallback_no_dist" | "runner_protocol_old" | "runner_pkg_root_not_found";
+}
+
+interface ResolvedRunner {
+  distDir: string;
+  pkgRoot: string;
+  source: "project" | "bundled";
+  resolvedFrom?: string;
+  version?: string;
+  pendingWarnings: RunnerWarning[];
+}
+
+/**
+ * Resolve the runner dist/ directory + package root.
+ *
+ * Preference: project-local `@glubean/runner` (found from `projectCwd`'s
+ * `node_modules` chain). Fallback: bundled (the consumer's own runner copy).
+ *
+ * Returns warnings to be yielded as `{ type: "warning", ... }` events at
+ * the start of every `run()` call. Always emits a warning when falling
+ * back to bundled (so users see why "configure() values..." errors may
+ * appear in a misconfigured project).
+ */
+function resolveRunnerRoot(
+  projectCwd: string,
+  bundledDistDir: string,
+  bundledPkgRoot: string,
+): ResolvedRunner {
+  const warnings: RunnerWarning[] = [];
+  try {
+    // Root `createRequire` at a stub path INSIDE the project cwd — not
+    // at `import.meta.url` (the workspace executor file). If we use the
+    // workspace URL, Node's resolver returns the workspace's own
+    // `@glubean/runner` via package self-reference (the `exports` field
+    // points back at itself), regardless of `paths: [projectCwd]`. With
+    // a cwd-rooted stub there's no self-reference and Node walks the
+    // project's node_modules chain correctly.
+    const req = createRequire(resolve(projectCwd, "__glubean_resolve_stub__.js"));
+    const mainEntry = req.resolve("@glubean/runner");
+
+    const pkgRoot = findPackageRoot(mainEntry, "@glubean/runner");
+    if (!pkgRoot) {
+      warnings.push({
+        code: "runner_pkg_root_not_found",
+        message: `Could not locate @glubean/runner's package.json above ${mainEntry}; using bundled runner.`,
+      });
+      return {
+        distDir: bundledDistDir,
+        pkgRoot: bundledPkgRoot,
+        source: "bundled",
+        pendingWarnings: warnings,
+      };
+    }
+
+    const projectDistDir = dirname(mainEntry);
+    if (!existsSync(resolve(projectDistDir, "harness.js"))) {
+      warnings.push({
+        code: "runner_fallback_no_dist",
+        message: `Project @glubean/runner at ${pkgRoot} has no built harness.js (looked in ${projectDistDir}); using bundled runner.`,
+      });
+      return {
+        distDir: bundledDistDir,
+        pkgRoot: bundledPkgRoot,
+        source: "bundled",
+        pendingWarnings: warnings,
+      };
+    }
+
+    let version: string | undefined;
+    let projectProtocol: string | undefined;
+    try {
+      const pkg = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf-8"));
+      version = pkg.version;
+      projectProtocol = pkg.glubeanRunnerProtocol;
+    } catch {
+      // best effort
+    }
+
+    // Min-protocol check: emit a warning if project's protocol is older
+    // than what this consumer needs, but DON'T fall back. Using project-
+    // local runner with an old protocol just means some new env channels
+    // may be silently ignored. Falling back to bundled when the project
+    // has its own SDK would re-introduce the dual-package hazard the
+    // whole fix exists to prevent. Project-local wins; missing features
+    // are surfaced via warning so the user knows to upgrade.
+    try {
+      const bundledPkg = JSON.parse(
+        readFileSync(resolve(bundledPkgRoot, "package.json"), "utf-8"),
+      );
+      const bundledMin: string | undefined = bundledPkg.glubeanRunnerProtocolMinimum;
+      if (bundledMin && (!projectProtocol || semverLt(projectProtocol, bundledMin))) {
+        warnings.push({
+          code: "runner_protocol_old",
+          message:
+            `Project @glubean/runner ${version ?? "<unknown>"} declares glubeanRunnerProtocol=${projectProtocol ?? "<unset>"}, ` +
+            `but this consumer was built for >= ${bundledMin}. ` +
+            `Using project-local runner anyway; some newer features may be silently unavailable. ` +
+            `Run \`npm i -D @glubean/runner@latest\` to silence.`,
+        });
+      }
+    } catch {
+      // bundled pkg.json unreadable — skip the check; happens in test fixtures
+    }
+
+    return {
+      distDir: projectDistDir,
+      pkgRoot,
+      source: "project",
+      resolvedFrom: mainEntry,
+      version,
+      pendingWarnings: warnings,
+    };
+  } catch {
+    // No project-local runner installed. Plan 1 AC4: emit a warning whenever
+    // bundled is used so users see why version-skew "configure() values..."
+    // errors may appear.
+    warnings.push({
+      code: "runner_fallback_no_project",
+      message:
+        `No project-local @glubean/runner found at ${projectCwd}; using consumer's bundled runner. ` +
+        `If your tests import @glubean/sdk from this project, install runner to keep module identity ` +
+        `consistent: \`npm i -D @glubean/runner\`.`,
+    });
+    return {
+      distDir: bundledDistDir,
+      pkgRoot: bundledPkgRoot,
+      source: "bundled",
+      pendingWarnings: warnings,
+    };
+  }
+}
+
+// ── End of project-local resolution ─────────────────────────────────────────
+
+// ── Sibling-file suggestions for missing test file (Plan 4) ────────────────
+
+/**
+ * Quick Levenshtein distance (capped at 5 for early termination).
+ */
+function editDistance(a: string, b: string, cap = 5): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > cap) return cap + 1;
+  const m = a.length;
+  const n = b.length;
+  let prev = new Array(n + 1).fill(0).map((_, i) => i);
+  let curr = new Array(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > cap) return cap + 1;
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+async function siblingSuggestions(missingPath: string): Promise<string[]> {
+  try {
+    const { readdir } = await import("node:fs/promises");
+    const parentDir = dirname(missingPath);
+    const wantedBase = missingPath.split("/").pop()!;
+    const candidates = await readdir(parentDir);
+    return candidates
+      .filter((c) => c.endsWith(".test.ts") || c.endsWith(".test.js") || c.endsWith(".test.mts"))
+      .map((c) => ({ name: c, full: resolve(parentDir, c) }))
+      .map(({ name, full }) => ({ full, d: editDistance(wantedBase, name) }))
+      .filter(({ d }) => d <= 5)
+      .sort((a, b) => a.d - b.d)
+      .slice(0, 5)
+      .map(({ full }) => full);
+  } catch {
+    return [];
+  }
+}
+
 
 // ── Event Types ─────────────────────────────────────────────────────────────
 
@@ -47,6 +280,14 @@ export type ExecutionEvent = { testId?: string } & (
     condition: boolean;
     message: string;
     stepIndex?: number;
+    /**
+     * Discriminator for executor-emitted diagnostic warnings. Set by the
+     * executor itself (e.g. "runner_fallback", "runner_protocol_old") so
+     * consumers can distinguish runner diagnostics from user-emitted
+     * `ctx.warn(false, "...")` soft warnings, which omit this field.
+     * Used by CLI's dedupe set and MCP's `warnings: []` collection.
+     */
+    code?: string;
   }
   | {
     type: "schema_validation";
@@ -73,8 +314,18 @@ export type ExecutionEvent = { testId?: string } & (
     reason?: string;
     peakMemoryBytes?: number;
     peakMemoryMB?: string;
+    // Rich fields for load-phase failures (Plan 4 — pre-check missing file).
+    missingPath?: string;
+    suggestions?: string[];
   }
-  | { type: "error"; message: string; reason?: "http_timeout" | "test_timeout" | "network" | "oom" }
+  | {
+    type: "error";
+    message: string;
+    reason?: "http_timeout" | "test_timeout" | "network" | "oom" | "test_file_missing";
+    stack?: string;
+    missingPath?: string;
+    suggestions?: string[];
+  }
   | {
     type: "step_start";
     index: number;
@@ -252,10 +503,58 @@ export class TestExecutor {
   private _tempPackageJson: "created" | "patched" | false = false;
   private _originalPackageJson?: string;
 
+  // ── Resolved runner dist (Plan 1 — project-local or bundled) ──────────
+  /** Directory containing harness.js, zero-project-register.mjs. */
+  private _runnerDistDir!: string;
+  /** Package root of the resolved runner — used for GLUBEAN_VENDORED_ROOT. */
+  private _runnerPkgRoot!: string;
+  /** "project" if resolved from cwd's node_modules, else "bundled". */
+  private _runnerSource!: "project" | "bundled";
+  /** Absolute path of the main entry that was resolved (telemetry). */
+  private _runnerResolvedFrom?: string;
+  /** Version field of the resolved runner package.json. */
+  private _runnerVersion?: string;
+  /**
+   * Warnings collected at constructor time that must be surfaced before
+   * any spawn. Yielded at the very start of every run() call (NOT cleared
+   * — see Plan 1 §3.1 R4 reasoning: ProjectRunner runs session setup via
+   * a `run()` call whose consumer doesn't render warnings, so first-call
+   * clearing would lose them).
+   *
+   * Carries a `code` so CLI/MCP consumers can distinguish runner diagnostics
+   * from `ctx.warn(false, ...)` user warnings (both share the same
+   * { type: "warning", condition: false } shape on the wire).
+   */
+  private _pendingWarnings: RunnerWarning[] = [];
+
   constructor(options: ExecutorOptions = {}) {
-    // Use .js (compiled) — works with tsx and matches npm-published dist/
-    this.harnessPath = resolve(__dirname, "harness.js");
+    const bundledDistDir = __dirname;
+    const bundledPkgRoot = resolve(__dirname, "..");
+    const cwd = options.cwd ?? process.cwd();
+    const resolved = resolveRunnerRoot(cwd, bundledDistDir, bundledPkgRoot);
+
+    this._runnerDistDir = resolved.distDir;
+    this._runnerPkgRoot = resolved.pkgRoot;
+    this._runnerSource = resolved.source;
+    this._runnerResolvedFrom = resolved.resolvedFrom;
+    this._runnerVersion = resolved.version;
+    this._pendingWarnings = resolved.pendingWarnings;
+
+    this.harnessPath = resolve(this._runnerDistDir, "harness.js");
     this.options = options;
+  }
+
+  /** @internal — exposed for testing / telemetry. */
+  get runnerSource(): "project" | "bundled" {
+    return this._runnerSource;
+  }
+  /** @internal */
+  get runnerResolvedFrom(): string | undefined {
+    return this._runnerResolvedFrom;
+  }
+  /** @internal */
+  get runnerVersion(): string | undefined {
+    return this._runnerVersion;
   }
 
   static fromSharedConfig(
@@ -401,14 +700,18 @@ export class TestExecutor {
 
     if (existsSync(join(cwd, "node_modules", "@glubean", "sdk"))) return;
 
-    const registerPath = resolve(__dirname, "zero-project-register.mjs");
+    // Plan 1: relocate zero-project subpaths with the harness — if harness
+    // moved to project-local runner, register + vendored root must move too,
+    // otherwise scratch mode mixes project harness with bundled @glubean/*
+    // resolution.
+    const registerPath = resolve(this._runnerDistDir, "zero-project-register.mjs");
     this._zeroProjectTsxArgs.push("--import", registerPath);
 
     // Use the runner package root as the synthetic parent. From there,
     // Node's normal package resolution finds sibling @glubean/* packages in
     // both workspace installs (packages/runner/node_modules) and published
     // installs (ancestor node_modules).
-    this._zeroProjectEnv["GLUBEAN_VENDORED_ROOT"] = resolve(__dirname, "..");
+    this._zeroProjectEnv["GLUBEAN_VENDORED_ROOT"] = this._runnerPkgRoot;
 
     const pkgPath = join(cwd, "package.json");
     if (!existsSync(pkgPath)) {
@@ -459,6 +762,64 @@ export class TestExecutor {
     context: ExecutionContext,
     options?: { timeout?: number; exportName?: string; testIds?: string[]; exportNames?: Record<string, string>; signal?: AbortSignal; concurrency?: number },
   ): AsyncGenerator<ExecutionEvent> {
+    // ── Plan 1 R6: yield pending warnings FIRST (before pre-check / session
+    //    / spawn). Do NOT clear after yielding: ProjectRunner may call run()
+    //    multiple times (session setup + each file), and the first call's
+    //    consumer may not render warnings. Consumers (CLI / MCP) dedupe by
+    //    message at render time.
+    //
+    //    Each warning carries a `code` so consumers can distinguish runner
+    //    diagnostics from `ctx.warn(false, ...)` user warnings (which omit
+    //    `code` — see ExecutionEvent.warning schema).
+    for (const w of this._pendingWarnings) {
+      yield { type: "warning", condition: false, message: w.message, code: w.code };
+    }
+
+    // ── Plan 4: file pre-check. Emit start + status:failed (matches harness's
+    //    "test not found" pattern) so ProjectRunner counts the failure and
+    //    MCP attributes it to the requested test. Skip for the synthetic
+    //    __session__ "test" — session files are discovered/validated upstream.
+    if (testId !== "__session__") {
+      const filePath = fileURLToPath(testUrl);
+      let preCheckFailure: { message: string; suggestions?: string[] } | undefined;
+      try {
+        const { stat } = await import("node:fs/promises");
+        const s = await stat(filePath);
+        if (!s.isFile()) {
+          preCheckFailure = { message: `Test path is not a file: ${filePath}` };
+        }
+      } catch {
+        preCheckFailure = {
+          message: `Test file not found: ${filePath}`,
+          suggestions: await siblingSuggestions(filePath),
+        };
+      }
+
+      if (preCheckFailure) {
+        // Codex R7 P2-2: ProjectRunner batch mode calls run() with
+        // testId="" + options.testIds=[a,b,c]. Empty testId means MCP
+        // / counters lose attribution. Emit one (start, status:failed)
+        // pair per requested testId so the failure attributes correctly.
+        const idsToAttribute = options?.testIds && options.testIds.length > 0
+          ? options.testIds
+          : [testId || filePath];
+        for (const id of idsToAttribute) {
+          yield { type: "start", id, name: id, testId: id };
+          yield {
+            type: "status",
+            status: "failed",
+            id,
+            testId: id,
+            error: preCheckFailure.message,
+            reason: "test_file_missing",
+            missingPath: filePath,
+            ...(preCheckFailure.suggestions && { suggestions: preCheckFailure.suggestions }),
+          };
+        }
+        return;
+      }
+    }
+
     // Auto-session: run setup on first call (skip for __session__ calls to avoid recursion)
     if (this._sessionEnabled && testId !== "__session__") {
       // Capture env from the first real test run so session setup can
@@ -557,8 +918,20 @@ export class TestExecutor {
         env[key] = value;
       }
     }
-    if (nodeOptions.length > 0) {
-      env["NODE_OPTIONS"] = nodeOptions.join(" ");
+    // Plan 4 (E): always enable source maps so strip-types stack frames
+    // translate back to original .ts source lines.
+    nodeOptions.push("--enable-source-maps");
+
+    // Plan 4 R3 P1: merge with caller-set NODE_OPTIONS (after options.env
+    // overrides have already mutated env[]) instead of overwriting. Pre-empts
+    // the regression where setting `options.env.NODE_OPTIONS = undefined`
+    // or `--max-old-space-size=4096` would be discarded.
+    const existingNodeOpts = env["NODE_OPTIONS"]?.trim();
+    const mergedNodeOpts = [existingNodeOpts, ...nodeOptions]
+      .filter(Boolean)
+      .join(" ");
+    if (mergedNodeOpts) {
+      env["NODE_OPTIONS"] = mergedNodeOpts;
     }
 
     // ── Zero-project mode (scratch) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Companion to PR #3 (Plan 1 — project-local runner resolution). Plan 1 transparently fixes the dual-package hazard whenever the project has its own \`@glubean/runner\`. This PR adds an explicit pre-spawn probe at the MCP tool entry that detects the residual unrecoverable case (project pins \`@glubean/sdk\` only, no project runner) and returns a structured \`sdk_version_skew\` error so the LLM agent surfaces an actionable install command, instead of letting the user hit the misleading \"configure() values...\" runtime error.

## Files

- \`packages/mcp/src/version-compat.ts\` (new, 167 lines) — \`checkSdkCompat(projectRoot)\` helper
- \`packages/mcp/src/index.ts\` (+~40 lines) — import + early return + versionInfo forwarding on every return path + safe-payload allowlist

## Design

- \`checkSdkCompat\` probes both bundled and project \`@glubean/sdk\` + \`@glubean/runner\` via cwd-rooted \`createRequire\` (same pattern as Plan 1's executor.ts).
- Returns \`ok: false\` with a discriminating \`failureCode\` field:
  - \`\"sdk_version_skew\"\` — project has @glubean/sdk + realpath differs from bundled + no project @glubean/runner. Recoverable: user installs runner.
  - \`\"mcp_packaging_bug\"\` — MCP itself can't resolve its bundled SDK. Not user's fault; file an issue.
- All other paths return \`ok: true\` with structured metadata (project / bundled versions, runner-installed flag).
- \`versionInfo\` forwarded on **every** \`runLocalTestsFromFile\` return path (skew, success, no-tests-matched, mutually-exclusive-input, etc.) so agent has full SDK/runner context regardless of outcome.
- Safe MCP payload allowlist (\`safe.versionInfo\`) forwards to the tool response.

## Codex review

Static codex review of impl found 2× P2, both fixed:
- P2-1: \`versionInfo\` missing from non-skew error returns (\`selected.length === 0\`, \`inputJson\`+\`bootstrapInput\` conflict, must-match-exactly-one-testId). Now forwarded on all.
- P2-2: \`checkSdkCompat\` had a second \`ok: false\` branch (bundled SDK unresolvable) overloading \`sdk_version_skew\`. Now differentiated via \`failureCode: \"mcp_packaging_bug\"\`.

## Plan + planning reviews

- Plan: [\`internal/30-execution/2026-05-23-mcp-compat-check/\`](https://github.com/glubean/internal/tree/main/30-execution/2026-05-23-mcp-compat-check)
- 7 rounds of codex review during planning

## Test plan

- [x] MCP unit tests: 29/29 green (no regression)
- [ ] Manual: run \`glubean_run_local_file\` against a project with \`@glubean/sdk\` pinned but \`@glubean/runner\` missing → expect \`sdk_version_skew\` error with install command in the agent's tool response

## Relationship to PR #3

**Depends on PR #3** (Plan 1 already moved \`@glubean/sdk\` from devDependencies to dependencies in MCP, which this PR builds on). Branch base is \`runner-version-skew-fix\`. After PR #3 merges, this PR will be rebased onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)