### PR TITLE
feat(mcp): SDK / runner version-skew probe (Plan 3)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -38,6 +38,7 @@ import {
 } from "@glubean/scanner";
 import type { BundleMetadata, ExportMeta, FileMeta, ScanResult } from "@glubean/scanner";
 import { MCP_PACKAGE_VERSION, DEFAULT_GENERATED_BY } from "./version.js";
+import { checkSdkCompat, type CompatResult } from "./version-compat.js";
 
 type Vars = Record<string, string>;
 const METADATA_SCHEMA_VERSION = "1";
@@ -781,10 +782,44 @@ export async function runLocalTestsFromFile(args: {
   error?: string;
   /** Runner-fallback or protocol warnings emitted by the executor. (Plan 1 AC6) */
   warnings?: string[];
+  /**
+   * SDK / runner version compat probe result (Plan 3).
+   * Always populated. When `ok: false`, tests were NOT run because we
+   * detected a dual-package hazard that would have produced misleading
+   * errors. See `versionInfo.message` for the install command.
+   */
+  versionInfo?: CompatResult;
 }> {
   const absolutePath = resolve(args.filePath);
   const testDir = dirname(absolutePath);
   const projectRoot = await findProjectRoot(testDir);
+
+  // Plan 3: SDK / runner version-skew probe. Fires BEFORE we spawn the
+  // harness so an unrecoverable dual-package hazard (project has @glubean/sdk
+  // pinned at a different version + no @glubean/runner installed → Plan 1's
+  // fallback path can't produce a hazard-free spawn) is reported as a
+  // structured `sdk_version_skew` error instead of a misleading runtime
+  // error inside the test. Plan 1's runner fix transparently handles the
+  // common case (project-local runner present); this probe only short-
+  // circuits the residual sdk-only scenario.
+  const versionInfo = checkSdkCompat(projectRoot);
+  if (!versionInfo.ok) {
+    const fileUrl = pathToFileURL(absolutePath).href;
+    return {
+      fileUrl,
+      projectRoot,
+      vars: {},
+      secrets: {},
+      results: [],
+      summary: { total: 0, passed: 0, failed: 0 },
+      // Failure class differentiates the two `ok: false` paths in checkSdkCompat:
+      //   - "sdk_version_skew" — recoverable; user installs @glubean/runner
+      //   - "mcp_packaging_bug" — MCP itself broken; file an issue
+      error: versionInfo.failureCode ?? "sdk_version_skew",
+      versionInfo,
+    };
+  }
+
   const traceConfig = await loadMcpTraceConfig(projectRoot);
 
   const envPath = await resolveEnvPath(projectRoot, args.envFile);
@@ -822,6 +857,7 @@ export async function runLocalTestsFromFile(args: {
         ? "No tests discovered in file. Check that exports use test() or contract.http.with() from @glubean/sdk."
         : `No tests matched filter "${args.filter}". Available: ${tests.map((t) => t.id).join(", ")}`,
       ...(discoveryErrors && discoveryErrors.length > 0 ? { importErrors: discoveryErrors } : {}),
+      versionInfo,
     };
   }
 
@@ -883,6 +919,7 @@ export async function runLocalTestsFromFile(args: {
         error:
           "inputJson and bootstrapInput are mutually exclusive. " +
           "Per attachment-model §5.1: explicit input bypasses the overlay, so bootstrap params would be ignored. Pick one channel per run.",
+        versionInfo,
       };
     }
     if (selected.length !== 1) {
@@ -900,6 +937,7 @@ export async function runLocalTestsFromFile(args: {
             ? `: ${selected.map((t) => t.id).slice(0, 10).join(", ")}`
             : "") +
           ".",
+        versionInfo,
       };
     }
     const targetTestId = selected[0]!.id;
@@ -1110,6 +1148,7 @@ export async function runLocalTestsFromFile(args: {
     summary: { total: results.length, passed, failed },
     ...(orchestrationError !== undefined && { error: orchestrationError }),
     ...(warningsArr.length > 0 && { warnings: warningsArr }),
+    versionInfo,
   };
 }
 
@@ -1276,6 +1315,12 @@ server.registerTool(
     // the user with mysterious "configure() values" errors.
     if (result.warnings && result.warnings.length > 0) {
       safe.warnings = result.warnings;
+    }
+    // Plan 3: forward structured compat info. Always include — even when
+    // tests ran successfully — so the agent has full SDK/runner version
+    // context if it wants to render it.
+    if (result.versionInfo) {
+      safe.versionInfo = result.versionInfo;
     }
 
     lastLocalRunSnapshot = {

--- a/packages/mcp/src/version-compat.ts
+++ b/packages/mcp/src/version-compat.ts
@@ -1,0 +1,210 @@
+/**
+ * SDK / runner version compat probe for the MCP server.
+ *
+ * Companion to Plan 1's project-local runner resolution. Plan 1 transparently
+ * routes spawn-time SDK identity through the project-local runner when one is
+ * installed. When NO project-local runner is installed (sdk-only projects),
+ * Plan 1 falls back to bundled and emits a `runner_fallback_no_project`
+ * warning — but the dual-package hazard still reproduces because the bundled
+ * harness's `@glubean/sdk` won't match user code's `@glubean/sdk`.
+ *
+ * This module's job: detect that scenario at MCP tool entry time, BEFORE we
+ * spawn the harness, and return a structured `sdk_version_skew` error to the
+ * agent so it surfaces an actionable install command instead of the user
+ * hitting the misleading "configure() values can only be accessed..." error.
+ *
+ * Discriminator: this probe is MCP-specific because (a) MCP responses go to
+ * an LLM agent who needs structured `versionInfo`, not a stack trace; (b)
+ * `npx -y @glubean/mcp@latest` causes silent version drift via the npm cache
+ * TTL — users don't pin MCP the way they pin CLI.
+ */
+
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+
+export interface CompatResult {
+  ok: boolean;
+  /**
+   * Differentiates failure modes when `ok: false`:
+   *   - "sdk_version_skew" — project pins @glubean/sdk at a realpath
+   *     different from bundled AND no project @glubean/runner is
+   *     installed. The dual-package hazard would reproduce. Recoverable
+   *     by `npm i -D @glubean/runner`.
+   *   - "mcp_packaging_bug" — MCP process can't resolve its own bundled
+   *     @glubean/sdk. Not the user's fault — file an issue against MCP.
+   * Omitted when `ok: true`.
+   */
+  failureCode?: "sdk_version_skew" | "mcp_packaging_bug";
+  projectSdkVersion?: string;
+  bundledSdkVersion: string;
+  projectRunnerInstalled: boolean;
+  projectRunnerVersion?: string;
+  bundledRunnerVersion?: string;
+  message?: string;
+}
+
+/**
+ * Walk up from a starting file looking for a package.json whose `name` field
+ * matches `expectedName`. Layout-independent — mirrors the helper in
+ * `@glubean/runner`'s executor.ts so MCP's probe survives the same bundler
+ * topologies. Returns the realpath of the package root.
+ */
+function findPackageRoot(startFile: string, expectedName: string): string | undefined {
+  let dir = dirname(startFile);
+  for (let i = 0; i < 16; i++) {
+    const candidate = resolve(dir, "package.json");
+    if (existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, "utf-8"));
+        if (pkg?.name === expectedName) {
+          try {
+            return realpathSync(dir);
+          } catch {
+            return dir;
+          }
+        }
+      } catch {
+        // continue walking — corrupt / non-json
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+  return undefined;
+}
+
+interface PkgInfo {
+  pkgDir: string;  // realpath of package root
+  version: string;
+}
+
+/**
+ * Resolve a package's main entry, then walk up to its package.json by name.
+ * Uses a cwd-rooted createRequire to avoid the workspace self-reference trap
+ * (see Plan 1 §3.1 for context). Returns undefined when not resolvable.
+ */
+function probePkg(name: string, projectCwd?: string): PkgInfo | undefined {
+  try {
+    const stubPath = projectCwd
+      ? resolve(projectCwd, "__glubean_compat_stub__.js")
+      : resolve(dirname(new URL(import.meta.url).pathname), "__bundled_stub__.js");
+    const req = createRequire(stubPath);
+    const mainEntry = req.resolve(name);
+    const pkgDir = findPackageRoot(mainEntry, name);
+    if (!pkgDir) return undefined;
+    const pkg = JSON.parse(readFileSync(resolve(pkgDir, "package.json"), "utf-8"));
+    return { pkgDir, version: pkg.version };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe the SDK + runner identities of the running MCP process and the
+ * caller's project. Returns `ok: false` only when the hazard is real:
+ * project has its own @glubean/sdk, the realpath differs from MCP's
+ * bundled SDK, AND project has no @glubean/runner installed (so Plan 1's
+ * project-local resolution would fall back to bundled).
+ *
+ * Every other case (no project SDK at all / matching SDK / project has
+ * runner) returns ok with structured metadata so the agent has full context.
+ */
+export function checkSdkCompat(projectRoot: string): CompatResult {
+  const bundledSdk = probePkg("@glubean/sdk");
+  const bundledRunner = probePkg("@glubean/runner");
+
+  if (!bundledSdk) {
+    return {
+      ok: false,
+      failureCode: "mcp_packaging_bug",
+      bundledSdkVersion: "<unresolved>",
+      projectRunnerInstalled: false,
+      message:
+        `@glubean/mcp is missing its runtime dependency on @glubean/sdk. ` +
+        `This is a packaging bug — please file an issue.`,
+    };
+  }
+
+  const projectSdk = probePkg("@glubean/sdk", projectRoot);
+  const projectRunner = probePkg("@glubean/runner", projectRoot);
+  const projectRunnerInstalled = projectRunner !== undefined;
+
+  if (!projectSdk) {
+    return {
+      ok: true,
+      bundledSdkVersion: bundledSdk.version,
+      bundledRunnerVersion: bundledRunner?.version,
+      projectRunnerInstalled,
+      projectRunnerVersion: projectRunner?.version,
+    };
+  }
+
+  if (projectSdk.pkgDir === bundledSdk.pkgDir) {
+    return {
+      ok: true,
+      projectSdkVersion: projectSdk.version,
+      bundledSdkVersion: bundledSdk.version,
+      bundledRunnerVersion: bundledRunner?.version,
+      projectRunnerInstalled,
+      projectRunnerVersion: projectRunner?.version,
+    };
+  }
+
+  if (projectRunnerInstalled && projectRunner) {
+    // Partial-upgrade hazard guard: project's @glubean/runner may have
+    // nested its OWN @glubean/sdk in its private node_modules (npm/pnpm
+    // sometimes leaves a nested copy when versions can't dedup). In that
+    // case the harness loads the runner's nested SDK while user test code
+    // loads project's direct SDK → different realpaths → dual-package
+    // hazard reproduces despite Plan 1's project-local runner resolution.
+    //
+    // Verify the runner's resolved SDK realpath matches the project's
+    // direct SDK realpath. If not, this is a real skew worth reporting.
+    const runnerNestedSdk = probePkg("@glubean/sdk", projectRunner.pkgDir);
+    if (runnerNestedSdk && runnerNestedSdk.pkgDir !== projectSdk.pkgDir) {
+      return {
+        ok: false,
+        failureCode: "sdk_version_skew",
+        projectSdkVersion: projectSdk.version,
+        bundledSdkVersion: bundledSdk.version,
+        bundledRunnerVersion: bundledRunner?.version,
+        projectRunnerInstalled: true,
+        projectRunnerVersion: projectRunner.version,
+        message:
+          `Project pins @glubean/sdk ${projectSdk.version} at ${projectSdk.pkgDir}, ` +
+          `but @glubean/runner ${projectRunner.version} resolves its own nested ` +
+          `@glubean/sdk ${runnerNestedSdk.version} at ${runnerNestedSdk.pkgDir}. ` +
+          `These are different module instances; tests will fail with a misleading ` +
+          `"configure() values can only be accessed during test execution" error. ` +
+          `Fix: align versions — e.g. \`npm dedupe\`, or update @glubean/runner to a ` +
+          `version that uses your pinned @glubean/sdk.`,
+      };
+    }
+
+    return {
+      ok: true,
+      projectSdkVersion: projectSdk.version,
+      bundledSdkVersion: bundledSdk.version,
+      bundledRunnerVersion: bundledRunner?.version,
+      projectRunnerInstalled: true,
+      projectRunnerVersion: projectRunner.version,
+    };
+  }
+
+  return {
+    ok: false,
+    failureCode: "sdk_version_skew",
+    projectSdkVersion: projectSdk.version,
+    bundledSdkVersion: bundledSdk.version,
+    bundledRunnerVersion: bundledRunner?.version,
+    projectRunnerInstalled: false,
+    message:
+      `Project pins @glubean/sdk ${projectSdk.version} but has no @glubean/runner installed; ` +
+      `MCP is using its bundled @glubean/runner${bundledRunner ? ` ${bundledRunner.version}` : ""} ` +
+      `+ @glubean/sdk ${bundledSdk.version}. These are different module instances; tests will fail ` +
+      `with a misleading "configure() values can only be accessed during test execution" error. ` +
+      `Fix: run "npm i -D @glubean/runner@${bundledRunner?.version ?? bundledSdk.version}" in the project.`,
+  };
+}


### PR DESCRIPTION
Re-opened after the original [PR #5](https://github.com/glubean/glubean/pull/5) was auto-closed when its base branch (\`runner-version-skew-fix\`) was deleted on merge of #3. Same commit content, now rebased onto main.

## Summary

Companion to #3 (Plan 1 — project-local runner resolution). Plan 1 transparently fixes the dual-package hazard whenever the project has its own \`@glubean/runner\`. This PR adds an explicit pre-spawn probe at the MCP tool entry that detects the residual unrecoverable case (project pins \`@glubean/sdk\` only, no project runner) and returns a structured \`sdk_version_skew\` error so the LLM agent surfaces an actionable install command, instead of letting the user hit the misleading "configure() values..." runtime error.

## Files

- \`packages/mcp/src/version-compat.ts\` (new) — \`checkSdkCompat(projectRoot)\` helper with layout-independent package walking + partial-upgrade hazard guard
- \`packages/mcp/src/index.ts\` — import + early return + \`versionInfo\` forwarding on every return path + safe-payload allowlist

## Codex review findings (all fixed)

- **P2** — \`versionInfo\` missing from non-skew error returns. Forwarded on all paths.
- **P2** — \`checkSdkCompat\` had a second \`ok: false\` branch (bundled SDK unresolvable) overloading \`sdk_version_skew\`. Differentiated via \`failureCode: \"mcp_packaging_bug\"\`.
- **P2** — Partial-upgrade hazard: project has \`@glubean/runner\` installed but its nested \`@glubean/sdk\` differs from project's direct SDK. Plan 1's project-local runner resolution still produces hazard. Added probe: when \`projectRunnerInstalled\`, verify runner's nested SDK realpath matches project's direct SDK realpath; if not, report skew with actionable \`npm dedupe\` suggestion.

## Test plan

- MCP unit tests: 29/29 green
- Will verify with dogfood + real partial-upgrade scenario after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)