### PR TITLE
Fix browser base URL resolution and journey filename diagnostics

### DIFF
--- a/packages/browser/src/page.ts
+++ b/packages/browser/src/page.ts
@@ -140,8 +140,11 @@ interface BrowserOptionsBase {
    */
   puppeteer?: PuppeteerLike;
   /**
-   * Optional var key whose runtime value is prepended to relative URLs in `goto()`.
+   * Optional base URL prepended to relative URLs in `goto()`.
+   * Accepts a runtime var key, a `{{KEY}}` template, or a literal absolute URL.
    * @example "APP_URL"
+   * @example "{{APP_URL}}"
+   * @example "https://app.example.com"
    */
   baseUrl?: string;
   /**

--- a/packages/browser/src/plugin.test.ts
+++ b/packages/browser/src/plugin.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { resolveTemplate, type GlubeanRuntime } from "@glubean/sdk";
+
+import { browser } from "./plugin.js";
+
+function makeRuntime(
+  vars: Record<string, string> = {},
+  secrets: Record<string, string> = {},
+): GlubeanRuntime {
+  return {
+    vars,
+    secrets,
+    http: {} as GlubeanRuntime["http"],
+    requireVar: (key) => {
+      const value = vars[key];
+      if (!value) throw new Error(`Missing required variable: ${key}`);
+      return value;
+    },
+    requireSecret: (key) => {
+      const value = secrets[key];
+      if (!value) throw new Error(`Missing required secret: ${key}`);
+      return value;
+    },
+    resolveTemplate: (template) => resolveTemplate(template, vars, secrets),
+    action: () => {},
+    trace: () => {},
+    event: () => {},
+    log: () => {},
+  };
+}
+
+function resolvedBaseUrl(
+  configured: string,
+  vars: Record<string, string> = {},
+): string | undefined {
+  const client = browser({ launch: true, baseUrl: configured }).create(
+    makeRuntime(vars),
+  );
+  return (client as unknown as { _baseUrl?: string })._baseUrl;
+}
+
+describe("browser baseUrl resolution", () => {
+  test("accepts a literal absolute URL", () => {
+    expect(resolvedBaseUrl("https://lingoak.app")).toBe(
+      "https://lingoak.app",
+    );
+  });
+
+  test("resolves a {{KEY}} template", () => {
+    expect(
+      resolvedBaseUrl("{{WEB_URL}}", { WEB_URL: "https://lingoak.app" }),
+    ).toBe("https://lingoak.app");
+  });
+
+  test("keeps supporting a bare runtime variable name", () => {
+    expect(
+      resolvedBaseUrl("WEB_URL", { WEB_URL: "https://lingoak.app" }),
+    ).toBe("https://lingoak.app");
+  });
+});

--- a/packages/browser/src/plugin.ts
+++ b/packages/browser/src/plugin.ts
@@ -93,11 +93,31 @@ function resolveLaunchOptions(
   return resolved;
 }
 
+/**
+ * Resolve the base URL while preserving the original bare-var-key contract.
+ *
+ * Unlike connection endpoints, a base URL is commonly a stable literal in a
+ * checked-in surface definition. Accepting all three authoring forms keeps
+ * relative `page.goto()` calls usable without forcing an otherwise-unneeded
+ * configure vars alias:
+ *
+ * - `"APP_URL"` — runtime var key (legacy form)
+ * - `"{{APP_URL}}"` — runtime template
+ * - `"https://app.example.com"` — literal absolute URL
+ */
+function resolveBaseUrl(
+  configured: string | undefined,
+  runtime: GlubeanRuntime,
+): string | undefined {
+  if (!configured) return undefined;
+  if (configured.includes("{{")) return runtime.resolveTemplate(configured);
+  if (/^https?:\/\//i.test(configured)) return configured;
+  return runtime.requireVar(configured);
+}
+
 export function browser(options: BrowserOptions): { __type: GlubeanBrowser; create: (runtime: GlubeanRuntime) => GlubeanBrowser } {
   return defineClientFactory((runtime: GlubeanRuntime): GlubeanBrowser => {
-    const baseUrl = options.baseUrl
-      ? runtime.vars[options.baseUrl] ?? undefined
-      : undefined;
+    const baseUrl = resolveBaseUrl(options.baseUrl, runtime);
 
     let browserPromise: Promise<Browser> | null = null;
 

--- a/packages/cli/src/commands/run-browser-filename-diagnostic.test.ts
+++ b/packages/cli/src/commands/run-browser-filename-diagnostic.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterAll, expect, test } from "vitest";
+
+import { runCli } from "../test-helpers.js";
+
+const fixtureDirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(
+    fixtureDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+test("an explicitly targeted browser journey with an unrecognized suffix gets a naming hint", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "glubean-browser-filename-"));
+  fixtureDirs.push(dir);
+  await writeFile(
+    join(dir, "login.journey.ts"),
+    `// @contract\nexport const loginJourney = { cases: {} };\n`,
+    "utf-8",
+  );
+
+  const { code, stdout, stderr } = await runCli(
+    ["run", "login.journey.ts", "--no-session"],
+    { cwd: dir },
+  );
+  const output = stdout + stderr;
+
+  expect(code).not.toBe(0);
+  expect(output).toContain("No test cases found");
+  expect(output).toContain("Name browser journeys *.browser.ts or *.contract.ts");
+  expect(output).toContain("login.journey.ts are not imported as contracts");
+});

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -887,7 +887,7 @@ export async function runCommand(
       }${colors.reset}`,
     );
     console.error(
-      `${colors.dim}Glubean looks for files matching *.test.ts, *.contract.ts, *.workflow.ts, or *.flow.ts in the target directory.${colors.reset}`,
+      `${colors.dim}Glubean looks for files matching *.test.ts, *.contract.ts, *.browser.ts, *.workflow.ts, or *.flow.ts in the target directory.${colors.reset}`,
     );
     console.error(
       `${colors.dim}Run "glubean run tests/" or "glubean run path/to/file.test.ts".${colors.reset}\n`,
@@ -1412,6 +1412,16 @@ export async function runCommand(
         isMultiFile ? ` in ${testFiles.length} file(s)` : " in file"
       }${colors.reset}`,
     );
+    const unclassifiedTargets = testFiles.filter(
+      (file) => classifyGlubeanFile(file) === undefined,
+    );
+    if (unclassifiedTargets.length > 0) {
+      console.error(
+        `${colors.dim}Glubean classifies runnable files by suffix. ` +
+          `Name browser journeys *.browser.ts or *.contract.ts; files such as ` +
+          `login.journey.ts are not imported as contracts.${colors.reset}`,
+      );
+    }
     if (discoveryFailedFiles.length > 0) {
       console.error(
         `${colors.dim}${discoveryFailedFiles.length} file(s) failed to import (see errors above) — ` +

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -45,7 +45,7 @@ export async function scanCommand(
   if (scanResult.fileCount === 0 && !hasContracts && !hasWorkflows) {
     console.log(`${colors.yellow}⚠️  No test, contract, or workflow files found.${colors.reset}`);
     console.log(
-      `${colors.dim}   Expected exported test()/contract declarations, or workflow() in *.workflow.ts (legacy: *.flow.ts).${colors.reset}\n`,
+      `${colors.dim}   Expected exported test(), contract declarations in *.contract.ts or *.browser.ts, or workflow() in *.workflow.ts (legacy: *.flow.ts).${colors.reset}\n`,
     );
     process.exit(1);
   }

--- a/packages/scanner/src/scanner.ts
+++ b/packages/scanner/src/scanner.ts
@@ -195,7 +195,7 @@ export class Scanner {
     if (!foundTestFile && !foundContractFile && !foundFlowFile) {
       errors.push(
         "No test, contract, or flow files found. " +
-          "Ensure your files are named *.test.ts, *.contract.ts, *.workflow.ts, or *.flow.ts.",
+          "Ensure your files are named *.test.ts, *.contract.ts, *.browser.ts, *.workflow.ts, or *.flow.ts.",
       );
     }
 
@@ -452,7 +452,7 @@ export class Scanner {
     ) {
       warnings.push(
         "No Glubean test, contract, or flow files found. " +
-          "Ensure your files are named *.test.ts, *.contract.ts, *.workflow.ts, or *.flow.ts.",
+          "Ensure your files are named *.test.ts, *.contract.ts, *.browser.ts, *.workflow.ts, or *.flow.ts.",
       );
     }
 


### PR DESCRIPTION
## Summary

- resolve `browser({ baseUrl })` from a bare runtime var key, a `{{KEY}}` template, or a literal absolute URL
- preserve the contract adapter's automatic `entry` navigation while allowing the authored step to execute its own `page.goto()` target
- explain the required `*.browser.ts` / `*.contract.ts` suffix when an explicitly targeted journey file is not classified as a contract
- include `*.browser.ts` in scanner and CLI discovery guidance

## Root cause

The browser client treated every configured `baseUrl` string as a raw key into `runtime.vars`. Literal URLs and `{{KEY}}` templates therefore produced no client base URL. The Mode A adapter navigates the contract `entry` before running authored steps, so that pre-step `/login` navigation failed first and made the later absolute `page.goto()` call appear stale even though it had not run.

## Validation

- `CI=1 pnpm -r build`
- `CI=1 pnpm -r test`
- `git diff --check`

Fixes #16
