### PR TITLE
fix(sdk): resolve templates in contract case request data

### DIFF
--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -19,7 +19,12 @@ import ky, { type KyInstance } from "ky";
 import { captureRequestBody, inferJsonSchema, truncateBody, truncateDeep } from "./http-trace.js";
 import { Expectation } from "@glubean/sdk";
 import type { EachRowMeta, GlubeanAction, GlubeanEvent, HttpSchemaOptions, MetricOptions, PollUntilOptions, SchemaEntry, SchemaIssue, SchemaLike, SwitchCase, Trace, ValidateOptions } from "@glubean/sdk";
-import { installCarrier, runWithRuntime } from "@glubean/sdk/internal";
+import {
+  getRequestSensitiveValues,
+  installCarrier,
+  maskRequestSensitiveValues,
+  runWithRuntime,
+} from "@glubean/sdk/internal";
 import type { InternalRuntime } from "@glubean/sdk/internal";
 import type {
   EngineContext,
@@ -426,6 +431,7 @@ export class RunnerCore {
             if (!ctx) return response;
             const state = reqState.get(options.context);
             const durationMs = Math.round(scheduler.now() - (state?.startTime ?? scheduler.now()));
+            const sensitiveValues = getRequestSensitiveValues(options.context);
             // `request` is the final (possibly hook-replaced) request — correct target.
             const pathname = pathnameOf(request.url);
             const trace: Trace = {
@@ -472,7 +478,15 @@ export class RunnerCore {
                   if (inferSchema && typeof parsedBody === "object" && parsedBody !== null) {
                     trace.responseSchema = inferJsonSchema(parsedBody);
                   }
-                  trace.responseBody = truncateArrays ? truncateDeep(parsedBody) : truncateBody(parsedBody);
+                  // Mask before truncateDeep can cut a long sensitive value
+                  // into a prefix that no longer matches the final mask pass.
+                  const safeParsedBody = maskRequestSensitiveValues(
+                    parsedBody,
+                    sensitiveValues,
+                  );
+                  trace.responseBody = truncateArrays
+                    ? truncateDeep(safeParsedBody)
+                    : truncateBody(safeParsedBody);
                 }
                 // Binary content types are intentionally skipped.
               } catch {
@@ -481,12 +495,18 @@ export class RunnerCore {
             }
 
             // ctx.trace emits the trace event + the derived `http:request` action.
-            ctx.trace(trace);
+            ctx.trace(maskRequestSensitiveValues(trace, sensitiveValues) as Trace);
             // Auto-metric for response time (node parity: harness.ts:1116).
             const urlPath = tryPathname(request.url);
+            const safeUrlPath = maskRequestSensitiveValues(
+              urlPath,
+              sensitiveValues,
+            ) as string | undefined;
             ctx.metric("http_duration_ms", durationMs, {
               unit: "ms",
-              tags: urlPath !== undefined ? { method: request.method, path: urlPath } : { method: request.method },
+              tags: safeUrlPath !== undefined
+                ? { method: request.method, path: safeUrlPath }
+                : { method: request.method },
             });
             return response;
           },

--- a/packages/runner/src/engine-parity.test.ts
+++ b/packages/runner/src/engine-parity.test.ts
@@ -40,6 +40,15 @@ beforeAll(async () => {
   await mkdir(TMP_DIR, { recursive: true });
   server = createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
+    if (url.pathname.startsWith("/echo/")) {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(Buffer.concat(chunks));
+      });
+      return;
+    }
     if (url.pathname === "/json") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true, items: [1, 2, 3] }));
@@ -172,7 +181,7 @@ async function assertParity(content: string, testId: string, ctx: RunCtx = {}, e
 const ptest = (name: string, fn: () => Promise<void>) => test(name, fn);
 
 const MODULE = `
-import { test, configure, defineClientFactory } from "@glubean/sdk";
+import { test, configure, contract, defineClientFactory } from "@glubean/sdk";
 export const passingTest = test(
   { id: "passingTest", name: "Passing Test", tags: ["unit"] },
   async (ctx) => { ctx.log("Hello from test"); ctx.assert(true, "Should pass"); }
@@ -499,6 +508,27 @@ export const httpFullTracePostTest = test(
     ctx.assert(res.status === 200, "200");
   }
 );
+export const httpSensitiveTraceTest = test(
+  { id: "httpSensitiveTraceTest", name: "full-trace masks contract request secrets" },
+  async (ctx) => {
+    const base = ctx.vars.require("BASE_URL");
+    const api = contract.http.with("trace-secret-api", { client: ctx.http });
+    const request = api("trace-secret-request", {
+      endpoint: "POST " + base + "/echo/:tenantId",
+      cases: {
+        ok: {
+          description: "send secret-backed request fields",
+          pathParams: { tenantId: "{{TRACE_SECRET}}" },
+          query: { tenant: "{{TRACE_SECRET}}" },
+          headers: { "X-Tenant": "{{TRACE_SECRET}}" },
+          body: { tenantRef: "prefix-{{TRACE_SECRET}}-suffix" },
+          expect: { status: 200 },
+        },
+      },
+    });
+    await request[0].fn(ctx);
+  }
+);
 export const httpTruncateBodyTest = test(
   { id: "httpTruncateBodyTest", name: "full-trace + truncateArrays truncates response body" },
   async (ctx) => {
@@ -812,6 +842,36 @@ ptest("engine parity: emitFullTrace GET (request/response headers + response bod
 
 ptest("engine parity: emitFullTrace POST captures request body", async () => {
   await assertParity(MODULE, "httpFullTracePostTest", { vars: { BASE_URL: baseUrl } }, { emitFullTrace: true });
+});
+
+ptest("engine parity: contract request secrets are masked before full-trace emission", async () => {
+  const file = await makeTempFile(MODULE);
+  const ctx = {
+    vars: { BASE_URL: baseUrl },
+    secrets: { TRACE_SECRET: "sk+live/abc=" + "x".repeat(96) },
+  };
+  const legacy = normalize(await rawEvents(
+    file,
+    "httpSensitiveTraceTest",
+    false,
+    ctx,
+    { emitFullTrace: true, truncateArrays: true },
+  ));
+  const engine = normalize(await rawEvents(
+    file,
+    "httpSensitiveTraceTest",
+    true,
+    ctx,
+    { emitFullTrace: true, truncateArrays: true },
+  ));
+
+  expect(engine).toEqual(legacy);
+  const serialized = JSON.stringify(legacy);
+  const secret = ctx.secrets.TRACE_SECRET;
+  expect(serialized).not.toContain(secret);
+  expect(serialized).not.toContain(secret.slice(0, 40));
+  expect(serialized).not.toContain(encodeURIComponent(secret));
+  expect(serialized).toContain("[REDACTED]");
 });
 
 ptest("engine parity: emitFullTrace + inferSchema → responseSchema on trace", async () => {

--- a/packages/runner/src/harness.ts
+++ b/packages/runner/src/harness.ts
@@ -18,6 +18,8 @@ import {
   setExplicitInput,
   setBootstrapInput,
   setForceStandalone,
+  getRequestSensitiveValues,
+  maskRequestSensitiveValues,
   type InternalRuntime,
 } from "@glubean/sdk/internal";
 // Workflow executor — now node-only and owned by this package (plan 0007). The host
@@ -1044,6 +1046,7 @@ const kyInstance = ky.create({
         // for the trace target; the trace state is keyed by the stable context.
         const trace = requestTraceMap.get(options.context);
         const duration = Math.round(performance.now() - (trace?.startTime ?? performance.now()));
+        const sensitiveValues = getRequestSensitiveValues(options.context);
 
         // Increment HTTP counters for summary
         { const t = currentTestCtx(); if (t) { t.httpRequestTotal++; if (response.status >= 400) t.httpErrorTotal++; } }
@@ -1122,11 +1125,18 @@ const kyInstance = ky.create({
                 traceData.responseSchema = inferJsonSchema(parsedBody);
               }
 
+              // Mask before truncation: truncateDeep may cut a long secret so
+              // the final whole-trace masking pass can no longer match it.
+              const safeParsedBody = maskRequestSensitiveValues(
+                parsedBody,
+                sensitiveValues,
+              );
+
               // Truncate body: aggressive (truncateArrays) or default (>1MB only)
               if (truncateArrays) {
-                traceData.responseBody = truncateDeep(parsedBody);
+                traceData.responseBody = truncateDeep(safeParsedBody);
               } else {
-                traceData.responseBody = truncateBody(parsedBody);
+                traceData.responseBody = truncateBody(safeParsedBody);
               }
             }
             // Binary content types are intentionally skipped
@@ -1141,14 +1151,22 @@ const kyInstance = ky.create({
         // workflow node promotes its grade and obeys the late-evidence
         // quarantine. Outside a workflow node this is the closure ctx as ever.
         const sink = __activeWorkflowNodeCtx() ?? ctx;
-        sink.trace(traceData as unknown as Trace);
+        const safeTraceData = maskRequestSensitiveValues(
+          traceData,
+          sensitiveValues,
+        ) as Record<string, unknown>;
+        sink.trace(safeTraceData as unknown as Trace);
 
         // Auto-metric for response time
         try {
           const pathname = new URL(request.url).pathname;
+          const safePathname = maskRequestSensitiveValues(
+            pathname,
+            sensitiveValues,
+          ) as string;
           sink.metric("http_duration_ms", duration, {
             unit: "ms",
-            tags: { method: request.method, path: pathname },
+            tags: { method: request.method, path: safePathname },
           });
         } catch {
           sink.metric("http_duration_ms", duration, {

--- a/packages/runner/src/workflow/execute.test.ts
+++ b/packages/runner/src/workflow/execute.test.ts
@@ -9,12 +9,16 @@ import type {
   CheckNode,
   WorkflowNode,
   WorkflowTeardown,
+  HttpClient,
+  HttpResponsePromise,
 } from "@glubean/sdk";
 import { GlubeanSkipError, contract, workflow, projectWorkflow } from "@glubean/sdk";
 import {
   __unregisterProtocolForTesting,
   getRegistry as getRegistryForEach,
   PollExhaustedError,
+  setRuntime,
+  type InternalRuntime,
 } from "@glubean/sdk/internal";
 import {
   makeNodeScope,
@@ -744,6 +748,61 @@ describe("runWorkflow — contract-call dispatch", () => {
     __unregisterProtocolForTesting("wf-fake");
     __unregisterProtocolForTesting("wf-needs");
     __unregisterProtocolForTesting("wf-veto");
+    setRuntime(undefined);
+  });
+
+  it("resolves case header and nested body templates through the full workflow executor", async () => {
+    const calls: Array<{ url: string; options: Record<string, unknown> }> = [];
+    const post = (url: string | URL | Request, options?: Record<string, unknown>) => {
+      calls.push({ url: String(url), options: options ?? {} });
+      const json = async () => ({});
+      const response = Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json,
+      });
+      return Object.assign(response, { json }) as unknown as HttpResponsePromise;
+    };
+    const client = Object.assign(post, { post }) as unknown as HttpClient;
+    const runtime: InternalRuntime = {
+      vars: { PROJECT_ID: "project-from-vars" },
+      secrets: { API_TOKEN: "secret-token" },
+      session: {},
+      http: client,
+    };
+    setRuntime(runtime);
+
+    const api = contract.http.with("workflow-template-api", { client });
+    const c = api("workflow-template-request", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "send environment-backed request data from a workflow call",
+          headers: { Authorization: "Bearer {{API_TOKEN}}" },
+          body: {
+            projectId: "{{PROJECT_ID}}",
+            nested: [{ projectId: "{{PROJECT_ID}}" }],
+          },
+          expect: { status: 200 },
+        },
+      },
+    });
+    const { ctx } = fakeBase();
+    const wf = workflow("http-template-workflow").call("send", c.case("ok")).build();
+
+    const result = await runWorkflow(wf, ctx);
+
+    expect(result.status).toBe("passed");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options.headers).toEqual({
+      Authorization: "Bearer secret-token",
+    });
+    expect(calls[0].options.json).toEqual({
+      projectId: "project-from-vars",
+      nested: [{ projectId: "project-from-vars" }],
+    });
   });
 
   it("honors a third-party adapter's validateCaseForFlow veto (§17 #8)", async () => {

--- a/packages/sdk/src/contract-http/adapter.test.ts
+++ b/packages/sdk/src/contract-http/adapter.test.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 // Import from main index so the HTTP adapter side-effect registration fires.
 import { contract } from "../index.js";
 import { readJsonBody } from "./adapter.js";
+import { REQUEST_SENSITIVE_VALUES } from "../request-trace-security.js";
 import type {
   ProtocolContract,
 } from "../contract-types.js";
@@ -422,6 +423,594 @@ test("GLU-156: multiple `{{KEY}}` placeholders in one path param segment all res
 
     await c[0].fn!(makeCtx());
     expect(client._calls[0].url).toBe("/v1/scoped/acme--widgets");
+  } finally {
+    cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Issue #15: case-level headers/body resolve runtime templates
+// ---------------------------------------------------------------------------
+
+test("case headers and nested JSON body resolve vars, secrets, and session templates", async () => {
+  const cleanup = installRuntime(
+    { PROJECT_ID: "project-from-vars", REGION: "us-east-1" },
+    { API_TOKEN: "secret-token" },
+    {
+      API_TOKEN: "session-token",
+      PROJECT_ID: "project-from-session",
+    },
+  );
+  try {
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("create-project-resource", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "create a resource with environment-backed request data",
+          headers: {
+            Authorization: "Bearer {{API_TOKEN}}",
+            "X-Project-Id": "{{PROJECT_ID}}",
+          },
+          body: {
+            projectId: "{{PROJECT_ID}}",
+            metadata: {
+              regions: ["primary-{{REGION}}", "literal"],
+              targets: [{ id: "{{PROJECT_ID}}" }],
+              enabled: true,
+              attempts: 2,
+              nullable: null,
+            },
+          },
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await c[0].fn!(makeCtx());
+
+    expect(client._calls[0].options.headers).toEqual({
+      Authorization: "Bearer session-token",
+      "X-Project-Id": "project-from-session",
+    });
+    expect(client._calls[0].options.json).toEqual({
+      projectId: "project-from-session",
+      metadata: {
+        regions: ["primary-us-east-1", "literal"],
+        targets: [{ id: "project-from-session" }],
+        enabled: true,
+        attempts: 2,
+        nullable: null,
+      },
+    });
+    const context = client._calls[0].options.context as {
+      [REQUEST_SENSITIVE_VALUES]: string[];
+    };
+    expect(context[REQUEST_SENSITIVE_VALUES]).toEqual(["session-token"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("literal case headers and body keep their identity without an execution runtime", async () => {
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const headers = { "X-Mode": "literal {{not a placeholder}}" };
+  const body = { nested: ["literal {{not a placeholder}}", { enabled: true }] };
+  const c = api("literal-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "send a request containing only literal values",
+        headers,
+        body,
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await c[0].fn!(makeCtx());
+
+  expect(client._calls[0].options.headers).toBe(headers);
+  expect(client._calls[0].options.json).toBe(body);
+});
+
+test("escaped valid placeholders are sent literally without an execution runtime", async () => {
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const c = api("escaped-template-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "send literal template syntax in request data",
+        headers: { "X-Template": "\\{{PROJECT_ID}}" },
+        body: { nested: ["\\{{PROJECT_ID}}"] },
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await c[0].fn!(makeCtx());
+
+  expect(client._calls[0].options.headers).toEqual({
+    "X-Template": "{{PROJECT_ID}}",
+  });
+  expect(client._calls[0].options.json).toEqual({
+    nested: ["{{PROJECT_ID}}"],
+  });
+});
+
+test("body resolution preserves descriptors, custom JSON serialization, and nested opaque values", async () => {
+  const cleanup = installRuntime({}, { API_TOKEN: "secret-token" });
+  try {
+    const symbolToken = Symbol("token");
+    const opaque = new (class OpaqueValue {
+      readonly value = "{{API_TOKEN}}";
+    })();
+    const toJSON = function (this: Record<PropertyKey, unknown>) {
+      return {
+        derived: `${String(this.token)}:${String(this.hiddenToken)}:${String(this[symbolToken])}`,
+        token: this.token,
+        opaque: this.opaque,
+      };
+    };
+    const body = Object.create(Object.prototype, {
+      token: {
+        configurable: false,
+        enumerable: true,
+        value: "{{API_TOKEN}}",
+        writable: false,
+      },
+      hiddenToken: {
+        configurable: false,
+        enumerable: false,
+        value: "{{API_TOKEN}}",
+        writable: false,
+      },
+      [symbolToken]: {
+        configurable: false,
+        enumerable: false,
+        value: "{{API_TOKEN}}",
+        writable: false,
+      },
+      opaque: {
+        configurable: true,
+        enumerable: true,
+        value: opaque,
+        writable: true,
+      },
+      toJSON: {
+        configurable: true,
+        enumerable: false,
+        value: toJSON,
+        writable: true,
+      },
+    }) as Record<string, unknown>;
+    Object.preventExtensions(body);
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("descriptor-safe-request", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "resolve data properties without changing object semantics",
+          body,
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await c[0].fn!(makeCtx());
+
+    const resolved = client._calls[0].options.json as Record<string, unknown>;
+    expect(resolved === body).toBe(false);
+    expect(Object.isExtensible(resolved)).toBe(false);
+    expect(Object.getOwnPropertyDescriptor(resolved, "token")).toMatchObject({
+      configurable: false,
+      enumerable: true,
+      value: "secret-token",
+      writable: false,
+    });
+    expect(Object.getOwnPropertyDescriptor(resolved, "toJSON")?.value).toBe(toJSON);
+    expect(Object.getOwnPropertyDescriptor(resolved, "hiddenToken")?.value).toBe("secret-token");
+    expect(Object.getOwnPropertyDescriptor(resolved, symbolToken)?.value).toBe("secret-token");
+    expect(resolved.opaque).toBe(opaque);
+    expect(opaque.value).toBe("{{API_TOKEN}}");
+    expect(JSON.parse(JSON.stringify(resolved))).toEqual({
+      derived: "secret-token:secret-token:secret-token",
+      token: "secret-token",
+      opaque: { value: "{{API_TOKEN}}" },
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("opaque body values pass through unchanged instead of being traversed", async () => {
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const body = new URLSearchParams({ projectId: "{{PROJECT_ID}}" });
+  const c = api("opaque-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "send an opaque URL-encoded body without implicit traversal",
+        contentType: "application/x-www-form-urlencoded",
+        body,
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await c[0].fn!(makeCtx());
+
+  expect(client._calls[0].options.body).toBe(body);
+  expect(body.get("projectId")).toBe("{{PROJECT_ID}}");
+});
+
+test("typed-array static bodies pass through unchanged", async () => {
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const body = new Uint8Array([1, 2, 3]);
+  const c = api("binary-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "send an opaque binary request body",
+        contentType: "application/octet-stream",
+        body,
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await c[0].fn!(makeCtx());
+
+  expect(client._calls[0].options.body).toBe(body);
+});
+
+test("a top-level string body resolves templates", async () => {
+  const cleanup = installRuntime({}, { API_TOKEN: "secret-token" });
+  try {
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("string-request", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "resolve a template in a top-level JSON string body",
+          body: "prefix-{{API_TOKEN}}",
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await c[0].fn!(makeCtx());
+
+    expect(client._calls[0].options.json).toBe("prefix-secret-token");
+    const context = client._calls[0].options.context as {
+      glubeanRoute: string;
+      [REQUEST_SENSITIVE_VALUES]: string[];
+    };
+    expect(context.glubeanRoute).toBe("POST /resources");
+    expect(context[REQUEST_SENSITIVE_VALUES]).toEqual(["secret-token"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("runtime replacement values remain terminal even when they contain template syntax", async () => {
+  const cleanup = installRuntime({}, { API_TOKEN: "value-{{NOT_RECURSIVE}}" });
+  try {
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("terminal-template-request", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "treat resolved runtime values as terminal data",
+          headers: { "X-Token": "{{API_TOKEN}}" },
+          body: { token: "{{API_TOKEN}}" },
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await c[0].fn!(makeCtx());
+
+    expect(client._calls[0].options.headers).toEqual({
+      "X-Token": "value-{{NOT_RECURSIVE}}",
+    });
+    expect(client._calls[0].options.json).toEqual({
+      token: "value-{{NOT_RECURSIVE}}",
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("path and query secret templates join the non-wire trace masking context", async () => {
+  const cleanup = installRuntime(
+    {},
+    { PATH_SECRET: "path-secret", QUERY_SECRET: "query-secret" },
+  );
+  try {
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("secret-url-request", {
+      endpoint: "GET /tenants/:tenantId/resources",
+      cases: {
+        ok: {
+          description: "mask secret-backed path and query values in traces",
+          pathParams: { tenantId: "{{PATH_SECRET}}" },
+          query: { cursor: "{{QUERY_SECRET}}" },
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await c[0].fn!(makeCtx());
+
+    expect(client._calls[0].url).toBe("/tenants/path-secret/resources");
+    expect(client._calls[0].options.searchParams).toEqual({
+      cursor: "query-secret",
+    });
+    const context = client._calls[0].options.context as {
+      [REQUEST_SENSITIVE_VALUES]: string[];
+    };
+    expect(context[REQUEST_SENSITIVE_VALUES]).toEqual([
+      "path-secret",
+      "query-secret",
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("array subclasses remain opaque and retain private instance state", async () => {
+  class StatefulArray extends Array<string> {
+    readonly #marker = "state-intact";
+
+    marker(): string {
+      return this.#marker;
+    }
+  }
+
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const body = new StatefulArray("{{API_TOKEN}}");
+  const c = api("array-subclass-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "preserve an opaque Array subclass body",
+        body,
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await c[0].fn!(makeCtx());
+
+  const sent = client._calls[0].options.json as StatefulArray;
+  expect(sent).toBe(body);
+  expect(sent[0]).toBe("{{API_TOKEN}}");
+  expect(sent.marker()).toBe("state-intact");
+});
+
+test("frozen nested bodies and headers keep integrity while resolving templates", async () => {
+  const cleanup = installRuntime(
+    { PROJECT_ID: "project-from-vars" },
+    { API_TOKEN: "secret-token" },
+  );
+  try {
+    const headers = {
+      Authorization: "Bearer {{API_TOKEN}}",
+      "X-Project-Id": "{{PROJECT_ID}}",
+    } as Record<string, string>;
+    Object.defineProperties(headers, {
+      hiddenProjectId: {
+        configurable: true,
+        enumerable: false,
+        value: "{{PROJECT_ID}}",
+        writable: true,
+      },
+    });
+    Object.freeze(headers);
+    const body = Object.freeze({
+      nested: Object.freeze({ projectId: "{{PROJECT_ID}}" }),
+    });
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("frozen-request", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "resolve a frozen request snapshot without making it mutable",
+          headers,
+          body,
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await c[0].fn!(makeCtx());
+
+    const sentHeaders = client._calls[0].options.headers as Record<string, string>;
+    const sentBody = client._calls[0].options.json as {
+      nested: { projectId: string };
+    };
+    expect(sentHeaders).toEqual({
+      Authorization: "Bearer secret-token",
+      "X-Project-Id": "project-from-vars",
+    });
+    expect(Object.isFrozen(sentHeaders)).toBe(true);
+    expect(sentBody).toEqual({ nested: { projectId: "project-from-vars" } });
+    expect(Object.isFrozen(sentBody)).toBe(true);
+    expect(Object.isFrozen(sentBody.nested)).toBe(true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("enumerable request accessors fail before the request is sent", async () => {
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const body = Object.defineProperty({}, "value", {
+    enumerable: true,
+    get: () => "literal",
+  });
+  const c = api("accessor-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "require stable data properties in request snapshots",
+        body,
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await expect(c[0].fn!(makeCtx())).rejects.toThrow(
+    "Accessor properties are not supported in contract request data",
+  );
+  expect(client._calls).toHaveLength(0);
+
+  const headers = Object.defineProperty({}, "X-Mode", {
+    enumerable: true,
+    get: () => "literal",
+  }) as Record<string, string>;
+  const headerCase = api("accessor-header-request", {
+    endpoint: "GET /resources",
+    cases: {
+      ok: {
+        description: "require stable header data properties",
+        headers,
+        expect: { status: 200 },
+      },
+    },
+  });
+  await expect(headerCase[0].fn!(makeCtx())).rejects.toThrow(
+    "Accessor properties are not supported in contract request data",
+  );
+  expect(client._calls).toHaveLength(0);
+});
+
+test("circular JSON-shaped bodies fail before the request is sent", async () => {
+  const client = makeMockClient({ status: 200, body: {} });
+  const api = contract.http.with("api", { client });
+  const body: Record<string, unknown> = { projectId: "literal" };
+  body.self = body;
+  const c = api("circular-request", {
+    endpoint: "POST /resources",
+    cases: {
+      ok: {
+        description: "reject a body graph that cannot be serialized as JSON",
+        body,
+        expect: { status: 200 },
+      },
+    },
+  });
+
+  await expect(c[0].fn!(makeCtx())).rejects.toThrow(
+    "Circular references are not supported in contract case bodies",
+  );
+  expect(client._calls).toHaveLength(0);
+});
+
+test("a missing body template fails before the request is sent", async () => {
+  const cleanup = installRuntime();
+  try {
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("missing-body-template", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "require every body template before sending the request",
+          body: { nested: { projectId: "{{MISSING_PROJECT_ID}}" } },
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await expect(c[0].fn!(makeCtx())).rejects.toThrow(
+      'Missing value for template placeholder "{{MISSING_PROJECT_ID}}"',
+    );
+    expect(client._calls).toHaveLength(0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a missing header template fails before the request is sent", async () => {
+  const cleanup = installRuntime();
+  try {
+    const client = makeMockClient({ status: 200, body: {} });
+    const api = contract.http.with("api", { client });
+    const c = api("missing-header-template", {
+      endpoint: "GET /resources",
+      cases: {
+        ok: {
+          description: "require every header template before sending the request",
+          headers: { Authorization: "Bearer {{MISSING_TOKEN}}" },
+          expect: { status: 200 },
+        },
+      },
+    });
+
+    await expect(c[0].fn!(makeCtx())).rejects.toThrow(
+      'Missing value for template placeholder "{{MISSING_TOKEN}}"',
+    );
+    expect(client._calls).toHaveLength(0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("workflow case execution resolves templates returned by body and header input functions", async () => {
+  const cleanup = installRuntime(
+    { PROJECT_ID: "project-from-vars" },
+    { API_TOKEN: "secret-token" },
+  );
+  try {
+    const client = makeMockClient({ status: 200, body: { ok: true } });
+    const api = contract.http.with("api", { client });
+    const c = api("workflow-request", {
+      endpoint: "POST /resources",
+      cases: {
+        ok: {
+          description: "resolve workflow-provided request templates at execution time",
+          headers: ({ authorization }: any) => ({ Authorization: authorization }),
+          body: ({ projectId }: any) => ({ projectId, nested: ["{{PROJECT_ID}}"] }),
+          expect: { status: 200 },
+        },
+      },
+    });
+    const { httpAdapter } = await import("./adapter.js");
+
+    await httpAdapter.executeCaseInFlow!({
+      ctx: makeCtx(),
+      contract: c,
+      caseKey: "ok",
+      resolvedInputs: {
+        authorization: "Bearer {{API_TOKEN}}",
+        projectId: "{{PROJECT_ID}}",
+      },
+    });
+
+    expect(client._calls[0].options.headers).toEqual({
+      Authorization: "Bearer secret-token",
+    });
+    expect(client._calls[0].options.json).toEqual({
+      projectId: "project-from-vars",
+      nested: ["project-from-vars"],
+    });
+    const context = client._calls[0].options.context as {
+      [REQUEST_SENSITIVE_VALUES]: string[];
+    };
+    expect(context[REQUEST_SENSITIVE_VALUES]).toEqual(["secret-token"]);
   } finally {
     cleanup();
   }

--- a/packages/sdk/src/contract-http/adapter.ts
+++ b/packages/sdk/src/contract-http/adapter.ts
@@ -56,7 +56,8 @@ import { genericMarkdownPart } from "../contract-artifacts.js";
 import { matchInboundCaseHttp, preflightInboundCaseHttp } from "./inbound-match.js";
 import { createRequire } from "node:module";
 import { getRuntime } from "../configure/runtime.js";
-import { resolveTemplate } from "../configure/template.js";
+import { resolveTemplate, TEMPLATE_RE } from "../configure/template.js";
+import { REQUEST_SENSITIVE_VALUES } from "../request-trace-security.js";
 
 // =============================================================================
 // Helpers — endpoint, params, request body, response headers
@@ -77,41 +78,250 @@ export function parseEndpoint(endpoint: string): { method: string; path: string 
  *  (GLU-148) read `context.glubeanRoute` in their ky `afterResponse` hook and stamp
  *  `trace.routeKey` from it, so a dashboard's endpoint-coverage join gets an exact
  *  routeKey match instead of falling back to heuristic URL inference. */
-function routeContext(method: string, path: string): { glubeanRoute: string } {
-  return { glubeanRoute: `${method} ${path}` };
+function routeContext(
+  method: string,
+  path: string,
+  sensitiveValues?: ReadonlySet<string>,
+): {
+  glubeanRoute: string;
+  [REQUEST_SENSITIVE_VALUES]?: string[];
+} {
+  return {
+    glubeanRoute: `${method} ${path}`,
+    ...(sensitiveValues && sensitiveValues.size > 0
+      ? { [REQUEST_SENSITIVE_VALUES]: [...sensitiveValues] }
+      : {}),
+  };
+}
+
+const RUNTIME_TEMPLATE_RE = new RegExp(TEMPLATE_RE.source);
+const RUNTIME_TEMPLATE_GLOBAL_RE = new RegExp(TEMPLATE_RE.source, "g");
+const ESCAPED_RUNTIME_TEMPLATE_RE = /\\(\{\{[\w-]+\}\})/g;
+
+function protectEscapedRuntimeTemplates(value: string): {
+  protectedValue: string;
+  restore: (resolved: string) => string;
+} {
+  const escapedTemplates: string[] = [];
+  let markerPrefix = "\uE000GLUBEAN_ESCAPED_TEMPLATE_";
+  while (value.includes(markerPrefix)) markerPrefix = `\uE000${markerPrefix}`;
+  const protectedValue = value.replace(
+    ESCAPED_RUNTIME_TEMPLATE_RE,
+    (_match, template: string) => {
+      const index = escapedTemplates.push(template) - 1;
+      return `${markerPrefix}${index}\uE001`;
+    },
+  );
+  return {
+    protectedValue,
+    restore: (resolved) => escapedTemplates.reduce(
+      (current, template, index) => current.replaceAll(
+        `${markerPrefix}${index}\uE001`,
+        template,
+      ),
+      resolved,
+    ),
+  };
 }
 
 /**
- * Resolve `{{KEY}}` env placeholders inside a path/query param value —
- * the SAME `{{KEY}}` syntax `configure()` resolves for vars/secrets/http
- * headers (GLU-156: a literal `params: { id: { value: "{{PROJECT_ID}}" } }`
- * was previously URL-encoded VERBATIM — `%7B%7BPROJECT_ID%7D%7D` — instead
- * of being resolved first). Fast-path on the common case (no braces) so
- * ordinary literal param values never need an active runtime.
+ * Resolve one runtime `{{KEY}}` template string. This is also the GLU-156
+ * path/query fix: encoding an unresolved `{{PROJECT_ID}}` produced
+ * `%7B%7BPROJECT_ID%7D%7D`. The fast path is load-bearing because literal
+ * contract values must remain usable without an installed execution runtime.
  */
-function resolveParamTemplate(value: string): string {
-  if (!value.includes("{{")) return value;
+function resolveRuntimeTemplateString(
+  value: string,
+  sensitiveValues?: Set<string>,
+): string {
+  const { protectedValue, restore } = protectEscapedRuntimeTemplates(value);
+  if (!RUNTIME_TEMPLATE_RE.test(protectedValue)) return restore(protectedValue);
   const runtime = getRuntime();
-  return resolveTemplate(value, runtime.vars, runtime.secrets, runtime.session);
+  if (sensitiveValues) {
+    for (const match of protectedValue.matchAll(RUNTIME_TEMPLATE_GLOBAL_RE)) {
+      const key = match[1];
+      const sessionValue = runtime.session?.[key];
+      const declaredSecret = runtime.secrets[key];
+      const sensitiveValue = declaredSecret
+        ? (typeof sessionValue === "string" ? sessionValue : declaredSecret)
+        : undefined;
+      if (sensitiveValue) sensitiveValues.add(sensitiveValue);
+    }
+  }
+  return restore(
+    resolveTemplate(
+      protectedValue,
+      runtime.vars,
+      runtime.secrets,
+      runtime.session,
+    ),
+  );
 }
 
-function extractParamValue(v: unknown): string {
-  if (typeof v === "string") return resolveParamTemplate(v);
+function extractParamValue(v: unknown, sensitiveValues?: Set<string>): string {
+  if (typeof v === "string") {
+    return resolveRuntimeTemplateString(v, sensitiveValues);
+  }
   if (v && typeof v === "object" && "value" in v) {
-    return resolveParamTemplate(String((v as { value: string }).value));
+    return resolveRuntimeTemplateString(
+      String((v as { value: string }).value),
+      sensitiveValues,
+    );
   }
   return String(v);
 }
 
 export function flattenParamValues(
   params: Record<string, unknown> | undefined,
+  sensitiveValues?: Set<string>,
 ): Record<string, string> | undefined {
   if (!params) return undefined;
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(params)) {
-    result[key] = extractParamValue(value);
+    result[key] = extractParamValue(value, sensitiveValues);
   }
   return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function preserveObjectIntegrity<T extends object>(source: object, clone: T): T {
+  if (!Object.isExtensible(source)) Object.preventExtensions(clone);
+  return clone;
+}
+
+type DescriptorMap = Record<PropertyKey, PropertyDescriptor>;
+
+function getDescriptorMap(value: object): DescriptorMap {
+  return Object.getOwnPropertyDescriptors(value) as unknown as DescriptorMap;
+}
+
+function cloneWithDescriptors(source: object, descriptors: DescriptorMap): object {
+  if (Array.isArray(source)) {
+    const lengthDescriptor = descriptors.length;
+    const clone = new Array(source.length);
+    Object.setPrototypeOf(clone, Object.getPrototypeOf(source));
+    for (const key of Reflect.ownKeys(descriptors)) {
+      if (key !== "length") Object.defineProperty(clone, key, descriptors[key]);
+    }
+    if (lengthDescriptor) Object.defineProperty(clone, "length", lengthDescriptor);
+    return preserveObjectIntegrity(source, clone);
+  }
+
+  const clone = Object.create(Object.getPrototypeOf(source), descriptors) as object;
+  return preserveObjectIntegrity(source, clone);
+}
+
+function assertNoEnumerableAccessors(source: object, descriptors: DescriptorMap): void {
+  for (const key of Object.keys(source)) {
+    const descriptor = descriptors[key];
+    if (descriptor && !("value" in descriptor)) {
+      throw new TypeError(
+        "Accessor properties are not supported in contract request data; " +
+          "use plain data properties or return them from a case body/headers function",
+      );
+    }
+  }
+}
+
+/**
+ * Resolve string leaves in JSON-shaped case bodies while preserving opaque
+ * body values (FormData, URLSearchParams, Blob, typed arrays, class instances,
+ * etc.). Uses structural sharing so a literal-only data body is returned
+ * unchanged. Enumerable accessors are rejected before the HTTP client runs;
+ * their timing and recursive-template semantics are not a stable data model.
+ */
+function resolveBodyTemplates(
+  value: unknown,
+  sensitiveValues: Set<string>,
+  ancestors: WeakSet<object> = new WeakSet<object>(),
+): unknown {
+  if (typeof value === "string") {
+    return resolveRuntimeTemplateString(value, sensitiveValues);
+  }
+
+  if (Array.isArray(value)) {
+    // Array subclasses may carry private constructor state that cannot be
+    // reproduced by descriptor cloning. They are opaque body values.
+    if (Object.getPrototypeOf(value) !== Array.prototype) return value;
+    if (ancestors.has(value)) {
+      throw new TypeError("Circular references are not supported in contract case bodies");
+    }
+    ancestors.add(value);
+    const descriptors = getDescriptorMap(value);
+    assertNoEnumerableAccessors(value, descriptors);
+    let changed = false;
+    try {
+      for (const key of Reflect.ownKeys(descriptors)) {
+        const descriptor = descriptors[key];
+        if (!("value" in descriptor)) continue;
+        const current = descriptor.value;
+        const next = resolveBodyTemplates(current, sensitiveValues, ancestors);
+        if (next !== current) {
+          descriptor.value = next;
+          changed = true;
+        }
+      }
+    } finally {
+      ancestors.delete(value);
+    }
+    if (!changed) return value;
+    return cloneWithDescriptors(value, descriptors);
+  }
+
+  if (!isPlainObject(value)) return value;
+  if (ancestors.has(value)) {
+    throw new TypeError("Circular references are not supported in contract case bodies");
+  }
+  ancestors.add(value);
+
+  const descriptors = getDescriptorMap(value);
+  assertNoEnumerableAccessors(value, descriptors);
+  let changed = false;
+  try {
+    for (const key of Reflect.ownKeys(descriptors)) {
+      const descriptor = descriptors[key];
+      if (!("value" in descriptor)) continue;
+      const current = descriptor.value;
+      const next = resolveBodyTemplates(current, sensitiveValues, ancestors);
+      if (next !== current) {
+        descriptor.value = next;
+        changed = true;
+      }
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+  if (!changed) return value;
+  return cloneWithDescriptors(value, descriptors) as Record<string, unknown>;
+}
+
+/** Resolve every case-level header value with the same runtime priority. */
+function resolveHeaderTemplates(
+  headers: Record<string, string> | undefined,
+  sensitiveValues: Set<string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+
+  const descriptors = getDescriptorMap(headers);
+  assertNoEnumerableAccessors(headers, descriptors);
+  let changed = false;
+  for (const key of Reflect.ownKeys(descriptors)) {
+    const descriptor = descriptors[key];
+    if (!("value" in descriptor) || typeof descriptor.value !== "string") continue;
+    const current = descriptor.value;
+    const next = resolveRuntimeTemplateString(current, sensitiveValues);
+    if (next !== current) {
+      descriptor.value = next;
+      changed = true;
+    }
+  }
+  if (!changed) return headers;
+  return cloneWithDescriptors(headers, descriptors) as Record<string, string>;
 }
 
 /**
@@ -546,17 +756,22 @@ async function executeStandaloneCase(
 
   // Resolve pathParams/query/body/headers using resolvedInput (not setup
   // state). Function-valued fields receive the logical input directly.
+  const sensitiveValues = new Set<string>();
   const pathParamsSlot = casePathParams(caseSpec, `case (${spec.endpoint})`);
   const rawParams = typeof pathParamsSlot === "function"
     ? pathParamsSlot(resolvedInput)
     : pathParamsSlot;
-  const params = flattenParamValues(rawParams as Record<string, unknown> | undefined);
+  const params = flattenParamValues(
+    rawParams as Record<string, unknown> | undefined,
+    sensitiveValues,
+  );
   const resolvedPath = resolveParams(path, params);
 
   const requestOptions: Record<string, unknown> = {};
-  const body = typeof caseSpec.body === "function"
+  const rawBody = typeof caseSpec.body === "function"
     ? (caseSpec.body as (input: unknown) => unknown)(resolvedInput)
     : caseSpec.body;
+  const body = resolveBodyTemplates(rawBody, sensitiveValues);
 
   const normalizedReq = normalizeRequest(spec.request);
   const effectiveContentType =
@@ -566,11 +781,11 @@ async function executeStandaloneCase(
     Object.assign(requestOptions, buildRequestBodyOptions(body, effectiveContentType));
   }
 
-  const headers = typeof caseSpec.headers === "function"
+  const rawHeaders = typeof caseSpec.headers === "function"
     ? (caseSpec.headers as (input: unknown) => Record<string, string>)(resolvedInput)
     : caseSpec.headers;
+  const headers = resolveHeaderTemplates(rawHeaders, sensitiveValues);
   if (headers) requestOptions.headers = headers;
-  requestOptions.context = routeContext(method, path);
 
   if (caseSpec.query) {
     const rawQuery = typeof caseSpec.query === "function"
@@ -578,8 +793,10 @@ async function executeStandaloneCase(
       : caseSpec.query;
     requestOptions.searchParams = flattenParamValues(
       rawQuery as Record<string, unknown> | undefined,
+      sensitiveValues,
     );
   }
+  requestOptions.context = routeContext(method, path, sensitiveValues);
 
   requestOptions.throwHttpErrors = false;
 
@@ -1018,6 +1235,7 @@ async function executeCaseInFlowHttp(input: {
   }
 
   // Resolve action fields using resolvedInputs for function-valued slots.
+  const sensitiveValues = new Set<string>();
   const pathParamsSlot = casePathParams(
     caseSpec,
     `case "${caseKey}" in contract "${contract._projection.id}"`,
@@ -1025,16 +1243,21 @@ async function executeCaseInFlowHttp(input: {
   const rawParams = typeof pathParamsSlot === "function"
     ? pathParamsSlot(resolvedInputs)
     : pathParamsSlot;
-  const params = flattenParamValues(rawParams as Record<string, unknown> | undefined);
+  const params = flattenParamValues(
+    rawParams as Record<string, unknown> | undefined,
+    sensitiveValues,
+  );
   const resolvedPath = resolveParams(path, params);
 
-  const body = typeof caseSpec.body === "function"
+  const rawBody = typeof caseSpec.body === "function"
     ? (caseSpec.body as (input: unknown) => unknown)(resolvedInputs)
     : caseSpec.body;
+  const body = resolveBodyTemplates(rawBody, sensitiveValues);
 
-  const headers = typeof caseSpec.headers === "function"
+  const rawHeaders = typeof caseSpec.headers === "function"
     ? (caseSpec.headers as (input: unknown) => Record<string, string>)(resolvedInputs)
     : caseSpec.headers;
+  const headers = resolveHeaderTemplates(rawHeaders, sensitiveValues);
 
   const normalizedReq = normalizeRequest(spec.request);
   const effectiveContentType =
@@ -1051,7 +1274,6 @@ async function executeCaseInFlowHttp(input: {
     );
   }
   if (headers) requestOptions.headers = headers;
-  requestOptions.context = routeContext(method, path);
 
   if (caseSpec.query) {
     const rawQuery = typeof caseSpec.query === "function"
@@ -1059,8 +1281,10 @@ async function executeCaseInFlowHttp(input: {
       : caseSpec.query;
     requestOptions.searchParams = flattenParamValues(
       rawQuery as Record<string, unknown>,
+      sensitiveValues,
     );
   }
+  requestOptions.context = routeContext(method, path, sensitiveValues);
 
   const methodLower = method.toLowerCase() as keyof HttpClient;
   let res;

--- a/packages/sdk/src/contract-http/types.ts
+++ b/packages/sdk/src/contract-http/types.ts
@@ -107,10 +107,16 @@ export interface ContractExpect<T = unknown> {
 // =============================================================================
 
 /**
- * Static-body shape for HTTP case `body` field. Excludes `unknown` (which
- * would swallow the function branch in a union and lose `Needs` typing for
- * function-valued bodies). Function-form `body: (input: Needs) => ...` only
- * matches when the static-form types reject the value.
+ * Static-body shape for HTTP case `body`. A top-level string and string leaves
+ * in plain objects/arrays resolve `{{KEY}}` templates at execution time.
+ * Non-string BodyInit values (FormData, URLSearchParams, Blob, BufferSource,
+ * and ReadableStream) are opaque to template traversal, then follow the normal
+ * content-type dispatch; set the matching non-JSON content type to send one as
+ * a raw body. Excludes `unknown`, which would swallow the function branch and
+ * lose `Needs` typing. A function-form body follows the same runtime rules for
+ * its return value. Enumerable accessor properties are rejected; use data
+ * properties, including from the function form. In a JavaScript/TypeScript
+ * string, write `\\{{KEY}}` to send the literal text `{{KEY}}`.
  */
 export type HttpStaticBody =
   | Record<string, unknown>
@@ -119,9 +125,7 @@ export type HttpStaticBody =
   | number
   | boolean
   | null
-  | FormData
-  | URLSearchParams
-  | Blob;
+  | BodyInit;
 
 /**
  * v0 HTTP case factory — closes the v3 P2 known-open ("HTTP body Needs
@@ -232,7 +236,12 @@ export interface ContractCase<T = unknown, Needs = void> extends BaseCaseSpec {
   /** Query parameters. */
   query?: Record<string, ParamValue> | ((input: Needs) => Record<string, string>);
 
-  /** Request headers merged with client headers. */
+  /**
+   * Request headers merged with client headers. String data-property values
+   * resolve `{{KEY}}` templates at execution time. Enumerable accessors are
+   * rejected; a function form must return a data-property record. Write
+   * `\\{{KEY}}` in source to send the literal text `{{KEY}}`.
+   */
   headers?: Record<string, string> | ((input: Needs) => Record<string, string>);
 
   /** Business-logic verify — runs after status and schema validation. */

--- a/packages/sdk/src/internal.ts
+++ b/packages/sdk/src/internal.ts
@@ -22,6 +22,11 @@ export {
   type RuntimeCarrier,
   type InternalRuntime,
 } from "./runtime-carrier.js";
+export {
+  getRequestSensitiveValues,
+  maskRequestSensitiveValues,
+  REQUEST_SENSITIVE_VALUES,
+} from "./request-trace-security.js";
 
 // Internal-only test hook for plugin install state. Public callers use
 // `installPlugin` / `listInstalledPlugins` from the main export. The matching

--- a/packages/sdk/src/request-trace-security.test.ts
+++ b/packages/sdk/src/request-trace-security.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import {
+  getRequestSensitiveValues,
+  maskRequestSensitiveValues,
+  REQUEST_SENSITIVE_VALUES,
+} from "./request-trace-security.js";
+
+describe("request trace sensitive-value masking", () => {
+  test("normalizes non-wire context values", () => {
+    expect(getRequestSensitiveValues({
+      [REQUEST_SENSITIVE_VALUES]: ["abc", "abcdef", "abc", ""],
+    })).toEqual(["abcdef", "abc"]);
+    expect(getRequestSensitiveValues(undefined)).toEqual([]);
+    expect(getRequestSensitiveValues({
+      [REQUEST_SENSITIVE_VALUES]: "nope",
+    })).toEqual([]);
+  });
+
+  test("masks longest overlapping and transport-encoded variants", () => {
+    const values = getRequestSensitiveValues({
+      [REQUEST_SENSITIVE_VALUES]: ["abc", "abcdef", "sk live/abc="],
+    });
+    const masked = maskRequestSensitiveValues(
+      "abcdef sk%20live%2Fabc%3D sk+live%2Fabc%3D",
+      values,
+    );
+
+    expect(masked).toBe("[REDACTED] [REDACTED] [REDACTED]");
+  });
+
+  test("masks exact fragments throughout nested trace data without mutating input", () => {
+    const trace = {
+      requestHeaders: { "x-tenant": "Bearer secret-token" },
+      requestBody: {
+        tenantRef: "prefix-secret-token-suffix",
+        nested: ["secret-token", { keep: true }],
+      },
+      responseBody: { echoed: "secret-token" },
+    };
+
+    const masked = maskRequestSensitiveValues(trace, ["secret-token"]);
+
+    expect(masked).toEqual({
+      requestHeaders: { "x-tenant": "Bearer [REDACTED]" },
+      requestBody: {
+        tenantRef: "prefix-[REDACTED]-suffix",
+        nested: ["[REDACTED]", { keep: true }],
+      },
+      responseBody: { echoed: "[REDACTED]" },
+    });
+    expect(trace.requestBody.tenantRef).toBe("prefix-secret-token-suffix");
+  });
+});

--- a/packages/sdk/src/request-trace-security.ts
+++ b/packages/sdk/src/request-trace-security.ts
@@ -1,0 +1,67 @@
+const REDACTED_VALUE = "[REDACTED]";
+
+export const REQUEST_SENSITIVE_VALUES = Symbol.for(
+  "@glubean/sdk/request-sensitive-values",
+);
+
+/** Read exact sensitive replacement values from ky's non-wire request context. */
+export function getRequestSensitiveValues(context: unknown): string[] {
+  if (!context || typeof context !== "object") return [];
+  const values = (context as { [REQUEST_SENSITIVE_VALUES]?: unknown })
+    [REQUEST_SENSITIVE_VALUES];
+  if (!Array.isArray(values)) return [];
+  const rawValues = values.filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  const variants = new Set<string>();
+  for (const value of rawValues) {
+    variants.add(value);
+    variants.add(encodeURIComponent(value));
+    const formEncoded = new URLSearchParams([["value", value]])
+      .toString()
+      .slice("value=".length);
+    variants.add(formEncoded);
+  }
+  // Longest-first is load-bearing for overlapping values: masking "abc"
+  // before "abcdef" would leave the suffix "def" visible.
+  return [...variants].sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Deep-clone JSON-shaped trace data and replace exact session/secret fragments
+ * before any trace event leaves the runner or engine process.
+ */
+export function maskRequestSensitiveValues(
+  value: unknown,
+  sensitiveValues: readonly string[],
+  seen: WeakMap<object, unknown> = new WeakMap<object, unknown>(),
+): unknown {
+  if (sensitiveValues.length === 0) return value;
+  if (typeof value === "string") {
+    let masked = value;
+    for (const sensitiveValue of sensitiveValues) {
+      if (sensitiveValue) masked = masked.split(sensitiveValue).join(REDACTED_VALUE);
+    }
+    return masked;
+  }
+  if (!value || typeof value !== "object") return value;
+  if (seen.has(value)) return seen.get(value);
+
+  if (Array.isArray(value)) {
+    const masked: unknown[] = [];
+    seen.set(value, masked);
+    for (const entry of value) {
+      masked.push(maskRequestSensitiveValues(entry, sensitiveValues, seen));
+    }
+    return masked;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+  const masked = Object.create(prototype) as Record<string, unknown>;
+  seen.set(value, masked);
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    masked[key] = maskRequestSensitiveValues(entry, sensitiveValues, seen);
+  }
+  return masked;
+}


### PR DESCRIPTION
## Summary

- resolve `{{KEY}}` in contract case headers and recursively through nested
  JSON-shaped body objects and arrays
- preserve opaque body values and object integrity, with `\\{{KEY}}` as the
  documented literal-placeholder escape
- mask secret-backed replacements from runner and engine trace evidence,
  including path/query transport encodings and echoed response data

## Root cause

Contract case path and query values used the canonical runtime template
resolver, but case headers and bodies bypassed it in both standalone and
workflow execution.

## Validation

- `CI=1 pnpm -r build`
- `CI=1 pnpm -r --workspace-concurrency=1 test` (3426 tests)
- Claude Code Opus 5/xhigh cross-host RFR: foundation threshold converged with
  zero findings including nits

Fixes #15
