### PR TITLE
feat(browser): add Chrome extension testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 
 # tsc inline output (build outputs go to dist/)
 packages/*/src/**/*.js
+!packages/browser/src/chrome-extension/fixtures/**/*.js
 packages/*/src/**/*.d.ts
 packages/*/src/**/*.js.map
 packages/*/src/**/*.d.ts.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versions follow [lockstep semver](./CLAUDE.md#version-policy) — all packages s
 
 ## [Unreleased]
 
+### Added
+- **Unpacked Chrome extension testing in `@glubean/browser`** (#19) — launch one or more extension directories with `browser({ launch: true, extensions })`; discover loaded extensions, workers, pages, and targets through `@glubean/browser/chrome-extension`; trigger real toolbar actions; verify native Side Panel open/close behavior; and test options pages and content scripts with dedicated guides and a real-Chrome smoke test. Extension-origin absolute URLs now remain intact when an application `baseUrl` is configured. Native Side Panel closing requires Chrome 141+.
+- **Pipe-transport attach failures are explicit in `@glubean/browser`** — `GlubeanBrowser.wsEndpoint()` now throws a descriptive error when Chrome has no CDP WebSocket endpoint, including extension-enabled sessions, instead of returning an unusable empty string.
+
+### Changed
+- **BREAKING: `@glubean/browser` now requires `puppeteer-core >=24.41.0 <26`** — Chrome extension discovery and toolbar actions use Puppeteer's high-level `Extension` API introduced in 24.41. Existing browser-plugin users on Puppeteer 22 or 23 must upgrade before installing this release.
+
 ## [0.10.3] — 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Same TypeScript file works as both API collection entry and CI regression test. 
 | Plugin | Protocol |
 |--------|----------|
 | [@glubean/auth](packages/auth) | Bearer, API key, OAuth 2.0 |
-| [@glubean/browser](packages/browser) | Browser automation (Puppeteer) |
+| [@glubean/browser](packages/browser) | Browser and Chrome extension automation (Puppeteer) |
 | [@glubean/graphql](packages/graphql) | GraphQL queries and mutations |
 | [@glubean/grpc](packages/grpc) | gRPC unary calls |
 | [@glubean/oauth-code](packages/oauth-code) | OAuth Authorization Code flow for explore mode |

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,0 +1,81 @@
+# @glubean/browser
+
+Glubean's Puppeteer plugin launches or connects to Chrome and wraps pages with
+test evidence, tracing, metrics, screenshots, request mocking, and browser
+lifecycle management.
+
+## Browser tests
+
+```ts
+import { configure, test } from "@glubean/sdk";
+import { browser } from "@glubean/browser";
+
+const { chrome } = configure({
+  plugins: {
+    chrome: browser({ launch: true, baseUrl: "APP_URL" }),
+  },
+});
+
+const browserTest = test.extend({
+  page: async (ctx, use) => {
+    const page = await chrome.newPage(ctx);
+    try {
+      await use(page);
+    } finally {
+      await page.close();
+    }
+  },
+});
+```
+
+## Chrome extension tests
+
+Load unpacked extension directories through the same browser client:
+
+```ts
+const { chrome } = configure({
+  plugins: {
+    chrome: browser({
+      launch: true,
+      extensions: ["apps/extension/dist"],
+    }),
+  },
+});
+```
+
+`extensions` accepts runtime templates such as `"{{EXTENSION_PATH}}"`, bare
+runtime variable keys, and literal paths. The directories are validated before
+Chrome starts. Extension launch mode requires Puppeteer's pipe transport and
+defaults to visible Chrome; set
+`launchOptions.headless` explicitly if the tested surfaces support headless
+execution.
+
+Pipe transport has no CDP WebSocket URL, so an extension-enabled session cannot
+be handed to `glubean qa attach`. Launch a separate browser client without
+`extensions` when an attachable QA session is required.
+
+Chrome-specific helpers are exported from `@glubean/browser/chrome-extension`:
+
+- manifest and unpacked-directory validation;
+- extension ID, worker, page, and target discovery;
+- content-script ready-message watchers;
+- toolbar-action triggering through Puppeteer's `Extension` API;
+- native side-panel open/close verification;
+- a `createExtensionTest()` convenience fixture.
+
+See Puppeteer's [Chrome extension guide](https://pptr.dev/guides/chrome-extensions)
+for the underlying extension runtime model.
+
+See the separate guides for [options pages](guides/chrome-extension/options.md),
+[side panels](guides/chrome-extension/sidepanel.md), and
+[content scripts](guides/chrome-extension/content-scripts.md).
+
+Run the package's real-Chrome acceptance test with:
+
+```sh
+pnpm --filter @glubean/browser test:chrome-extension:smoke
+```
+
+The high-level extension helpers require `puppeteer-core >= 24.41.0`. Closing a
+native side panel requires Chrome 141 or newer because it uses
+`chrome.sidePanel.close()` inside the extension service worker.

--- a/packages/browser/guides/chrome-extension/README.md
+++ b/packages/browser/guides/chrome-extension/README.md
@@ -1,0 +1,68 @@
+# Chrome extension surface guides
+
+One `@glubean/browser` client can load an unpacked extension and test each of
+its runtime surfaces. The proof is different for each surface:
+
+| Surface | Entry point | Primary proof |
+| --- | --- | --- |
+| Options page | Declared `chrome-extension://` document | UI, controls, and storage behavior |
+| Side panel | Toolbar action or declared document | Native open/close state and rendered panel UI |
+| Content script | A web URL matching `content_scripts.matches` | Ready message, DOM change, or page/extension bridge |
+
+## Shared setup
+
+```ts
+import path from "node:path";
+import {
+  createExtensionTest,
+  resolveUnpackedExtension,
+} from "@glubean/browser/chrome-extension";
+
+export const extension = resolveUnpackedExtension(
+  path.resolve(process.env.CHROME_EXTENSION_PATH ?? "apps/extension/dist"),
+);
+
+export const { test } = createExtensionTest({
+  extensions: extension.path,
+  baseUrl: "APP_URL",
+  launchOptions: {
+    userDataDir: ".glubean/chrome-profile",
+  },
+});
+```
+
+Use a unique `userDataDir` per concurrently running worker, or omit it and let
+Puppeteer create an isolated temporary profile. Chrome rejects two processes
+that try to own the same profile directory.
+
+Extension mode defaults to visible Chrome. On a display-less CI runner, either
+use Xvfb or set `launchOptions.headless: true` after verifying the tested
+extension surfaces work in Chrome's current headless mode.
+
+Because extension launch uses pipe transport, it has no CDP WebSocket URL and
+cannot be reused by `glubean qa attach`. Use a separate launch without
+`extensions` for attachable QA sessions.
+
+`ctx.page.goto()` accepts both application-relative paths and absolute
+`chrome-extension://` URLs even when `baseUrl` is configured.
+The `extensions` option also accepts literal paths, `"{{EXTENSION_PATH}}"`
+templates, or a bare runtime variable key such as `"EXTENSION_PATH"`.
+
+Run a guide as a normal Glubean test:
+
+```sh
+glubean run tests/chrome-extension/options.test.ts
+```
+
+When only one extension is loaded, `getInstalledExtension()` discovers its
+runtime ID directly from Puppeteer:
+
+```ts
+import { getInstalledExtension } from "@glubean/browser/chrome-extension";
+
+const loaded = await getInstalledExtension(ctx.page.raw.browser());
+console.log(loaded.id, loaded.name, loaded.version);
+```
+
+If multiple extensions are loaded, select one by `{ id }`, `{ name }`, or
+`{ path }`.

--- a/packages/browser/guides/chrome-extension/content-scripts.md
+++ b/packages/browser/guides/chrome-extension/content-scripts.md
@@ -1,0 +1,89 @@
+# Testing content scripts
+
+Content scripts run inside web pages whose URLs match the manifest. They are
+not opened as `chrome-extension://` documents, so test them through the same
+observable boundary used by the application: DOM changes, messages, or
+extension side effects.
+See Chrome's [content script documentation](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts).
+
+## Ready message at document start
+
+Install the watcher before navigation. This prevents a `document_start` ready
+message from racing past the test listener.
+
+```ts
+import {
+  installExtensionReadyWatcher,
+} from "@glubean/browser/chrome-extension";
+import { test } from "./setup.js";
+
+export const contentScriptInjection = test(
+  {
+    id: "extension-content-script-injects-on-matching-page",
+    name: "The content script announces readiness on a matching page",
+    tags: ["browser", "extension", "content-script"],
+  },
+  async (ctx) => {
+    const ready = await installExtensionReadyWatcher(ctx.page.raw, {
+      keys: ["__glubean"],
+    });
+    try {
+      await ctx.page.goto("/content-script-fixture", {
+        waitUntil: "domcontentloaded",
+      });
+
+      const event = await ready.wait();
+      ctx.expect(event.key).toBe(
+        "__glubean",
+        "the matching content script announces its namespace",
+      );
+      ctx.expect(event.version).toBeDefined(
+        "the ready envelope identifies the loaded extension version",
+      );
+    } finally {
+      await ready.dispose();
+    }
+  },
+);
+```
+
+The content script side of that contract is a normal top-level page message:
+
+```ts
+window.postMessage({
+  __glubean: "ready",
+  version: chrome.runtime.getManifest().version,
+}, "*");
+```
+
+The object key must be one of the watcher's `keys`, and its value must be the
+string `"ready"`. The optional `version` is returned to the test. The watcher
+observes the top-level page; use an explicit iframe probe for content scripts
+configured with `all_frames: true`.
+
+The final URL must match `content_scripts.matches`, including scheme, host, and
+path. Redirects can move a page out of scope. A deliberate non-matching URL is
+a separate negative case.
+
+## DOM and message-bridge behavior
+
+When the script does not publish a ready envelope, wait for a stable DOM marker:
+
+```ts
+await ctx.page.goto("/content-script-fixture");
+await ctx.page.raw.waitForFunction(
+  () => document.documentElement.dataset.extensionReady === "true",
+);
+
+ctx.expect(await ctx.page.raw.$eval(
+  "[data-testid=extension-banner]",
+  (element) => element.textContent?.trim(),
+)).toBe("Extension connected", "the content script renders its banner");
+```
+
+For a `window.postMessage` bridge, install the response listener before sending
+the request and assert the correlation ID and payload that the web app receives.
+
+Puppeteer 24.41+ also exposes `page.extensionRealms()` for direct isolated-world
+evaluation. Prefer black-box page behavior for product tests; use extension
+realms when the isolated-world state itself is the contract under test.

--- a/packages/browser/guides/chrome-extension/options.md
+++ b/packages/browser/guides/chrome-extension/options.md
@@ -1,0 +1,54 @@
+# Testing an extension options page
+
+Chrome extensions declare an options document with `options_ui.page` or the
+legacy `options_page` key. Resolve that declaration from the built manifest,
+then test the extension-origin document like a normal instrumented page.
+See Chrome's [options page manifest documentation](https://developer.chrome.com/docs/extensions/develop/ui/options-page).
+
+```ts
+import {
+  extensionPageUrl,
+  getInstalledExtension,
+  resolveExtensionPagePath,
+} from "@glubean/browser/chrome-extension";
+import { extension, test } from "./setup.js";
+
+const optionsPath = resolveExtensionPagePath(extension, "options");
+
+export const optionsPage = test(
+  {
+    id: "extension-options-page-renders-and-saves",
+    name: "The extension options page renders and saves a setting",
+    tags: ["browser", "extension", "options"],
+  },
+  async (ctx) => {
+    const loaded = await getInstalledExtension(ctx.page.raw.browser(), {
+      path: extension.path,
+    });
+
+    await ctx.page.goto(extensionPageUrl(loaded.id, optionsPath), {
+      waitUntil: "domcontentloaded",
+    });
+    await ctx.page.raw.waitForSelector("[data-testid=options-root]");
+
+    ctx.expect(await ctx.page.title()).toBe(
+      "Extension Options",
+      "the manifest-declared options document renders",
+    );
+
+    await ctx.page.click("#enabled");
+    ctx.expect(await ctx.page.raw.$eval(
+      "#enabled",
+      (element) => (element as HTMLInputElement).checked,
+    )).toBe(true, "the options control changes state");
+  },
+);
+```
+
+For persisted settings, reopen the document or evaluate `chrome.storage` from
+the options page and assert the saved value. A reachability-only assertion is
+too weak: it misses broken scripts, missing controls, and storage failures.
+
+This test proves the options document itself. If the requirement is that users
+can discover it through `chrome://extensions`, keep that Chrome-owned
+navigation as a separate UI acceptance case.

--- a/packages/browser/guides/chrome-extension/sidepanel.md
+++ b/packages/browser/guides/chrome-extension/sidepanel.md
@@ -1,0 +1,70 @@
+# Testing a side panel
+
+There are two useful levels of Side Panel proof:
+
+1. open the manifest-declared HTML document directly to test its UI in
+   isolation;
+2. trigger the real extension toolbar action and verify Chrome opens and closes
+   the native side panel.
+
+The second level is supported by Puppeteer's `Extension` API. It avoids calling
+`chrome.sidePanel.open()` from an arbitrary script, which Chrome rejects unless
+the call follows a user action.
+See Chrome's [Side Panel API reference](https://developer.chrome.com/docs/extensions/reference/api/sidePanel).
+
+```ts
+import {
+  closeExtensionSidePanel,
+  resolveExtensionPagePath,
+  triggerExtensionAction,
+  waitForExtensionOwnedPage,
+  waitForExtensionPageClosed,
+  waitForExtensionWorker,
+} from "@glubean/browser/chrome-extension";
+import { extension, test } from "./setup.js";
+
+const sidePanelPath = resolveExtensionPagePath(extension, "sidepanel");
+
+export const nativeSidePanel = test(
+  {
+    id: "extension-side-panel-opens-and-closes",
+    name: "The toolbar action opens and closes the extension side panel",
+    tags: ["browser", "extension", "sidepanel"],
+  },
+  async (ctx) => {
+    await ctx.page.goto("/sidepanel-fixture");
+
+    const loaded = await triggerExtensionAction(ctx.page.raw, {
+      path: extension.path,
+    });
+    const panel = await waitForExtensionOwnedPage(loaded, sidePanelPath);
+    await panel.waitForSelector("[data-testid=sidepanel-root]");
+
+    ctx.expect(await panel.title()).toBe(
+      "Extension Side Panel",
+      "the toolbar action opens the declared side-panel document",
+    );
+
+    const worker = await waitForExtensionWorker(
+      ctx.page.raw.browser(),
+      loaded.id,
+    );
+    await closeExtensionSidePanel(worker.worker);
+    await waitForExtensionPageClosed(loaded, panel);
+  },
+);
+```
+
+The extension must declare the `sidePanel` permission and configure its action
+to open the panel, for example with
+`chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })`.
+
+`triggerExtensionAction()` requires `puppeteer-core >= 24.41.0`.
+`closeExtensionSidePanel()` evaluates `chrome.sidePanel.close({ windowId })` in
+the extension worker and therefore requires Chrome 141 or newer. Pass an
+explicit `{ windowId }` when the test owns multiple Chrome windows.
+
+To isolate panel rendering from browser action behavior, navigate directly to
+`extensionPageUrl(loaded.id, sidePanelPath)` in a separate test. That is useful
+component-level proof, but it does not prove the toolbar action or native panel
+container.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,29 +9,37 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./chrome-extension": {
+      "types": "./dist/chrome-extension/index.d.ts",
+      "import": "./dist/chrome-extension/index.js",
+      "default": "./dist/chrome-extension/index.js"
     }
   },
   "files": [
     "NOTICE",
-    "dist"
+    "dist",
+    "guides",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:chrome-extension:smoke": "vitest run src/chrome-extension/smoke.test.ts"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
     "@glubean/sdk": "workspace:*",
-    "puppeteer-core": "^24.0.0"
+    "puppeteer-core": "^24.41.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"
   },
   "peerDependencies": {
-    "puppeteer-core": ">=22"
+    "puppeteer-core": ">=24.41.0 <26"
   },
   "peerDependenciesMeta": {
     "puppeteer-core": {

--- a/packages/browser/src/chrome-extension/actions.test.ts
+++ b/packages/browser/src/chrome-extension/actions.test.ts
@@ -1,0 +1,181 @@
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Browser, Extension, Page, Target, WebWorker } from "puppeteer-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  closeExtensionSidePanel,
+  getInstalledExtension,
+  triggerExtensionAction,
+  waitForExtensionOwnedPage,
+  waitForExtensionPageClosed,
+} from "./actions.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
+
+function fakeExtension(overrides: Partial<Extension> = {}): Extension {
+  return {
+    id: "abc123",
+    name: "Fixture Extension",
+    version: "1.0.0",
+    path: "/tmp/fixture-extension",
+    enabled: true,
+    pages: async () => [],
+    workers: async () => [],
+    triggerAction: async () => {},
+    ...overrides,
+  } as Extension;
+}
+
+function fakeBrowser(extensions: Extension[]): Browser {
+  return {
+    extensions: async () => new Map(extensions.map((extension) => [extension.id, extension])),
+  } as unknown as Browser;
+}
+
+describe("installed extension actions", () => {
+  it("selects a loaded extension by id, name, or path", async () => {
+    const extension = fakeExtension();
+    const browser = fakeBrowser([extension]);
+
+    expect(await getInstalledExtension(browser)).toBe(extension);
+    expect(await getInstalledExtension(browser, "abc123")).toBe(extension);
+    expect(await getInstalledExtension(browser, { name: "Fixture Extension" })).toBe(extension);
+    expect(await getInstalledExtension(browser, { path: "/tmp/fixture-extension" })).toBe(extension);
+  });
+
+  it("waits for Chrome to finish registering an unpacked extension", async () => {
+    const extension = fakeExtension();
+    let calls = 0;
+    const browser = {
+      extensions: async () => new Map(
+        calls++ === 0 ? [] : [[extension.id, extension]],
+      ),
+    } as unknown as Browser;
+
+    expect(await getInstalledExtension(browser, undefined, {
+      timeout: 500,
+      interval: 1,
+    })).toBe(extension);
+    expect(calls).toBe(2);
+  });
+
+  it("triggers the toolbar action on the selected page", async () => {
+    const triggerAction = vi.fn(async () => {});
+    const extension = fakeExtension({ triggerAction });
+    const browser = fakeBrowser([extension]);
+    const page = { browser: () => browser } as unknown as Page;
+
+    expect(await triggerExtensionAction(page)).toBe(extension);
+    expect(triggerAction).toHaveBeenCalledWith(page);
+  });
+
+  it("requires a selector when more than one extension is loaded", async () => {
+    const browser = fakeBrowser([
+      fakeExtension(),
+      fakeExtension({ id: "def456", name: "Second Extension" }),
+    ]);
+
+    await expect(getInstalledExtension(browser)).rejects.toThrow(
+      "2 Chrome extensions are loaded",
+    );
+    await expect(getInstalledExtension(browser, {})).rejects.toThrow(
+      "2 Chrome extensions are loaded",
+    );
+  });
+
+  it("rejects an empty string selector immediately", async () => {
+    await expect(getInstalledExtension(fakeBrowser([]), "")).rejects.toThrow(
+      "id must not be empty",
+    );
+  });
+
+  it("matches an extension path through a filesystem symlink", async () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), "glubean-extension-path-"));
+    const linkedPath = join(tempDirectory, "extension-link");
+    symlinkSync(fixture, linkedPath, process.platform === "win32" ? "junction" : "dir");
+    try {
+      const extension = fakeExtension({ path: fixture });
+      await expect(getInstalledExtension(
+        fakeBrowser([extension]),
+        { path: linkedPath },
+        { timeout: 0 },
+      )).resolves.toBe(extension);
+    } finally {
+      rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("waits for an owned page to open and close", async () => {
+    const target = {} as Target;
+    const page = {
+      url: () => "chrome-extension://abc123/sidepanel.html?tab=7#/home",
+      isClosed: () => false,
+      target: () => target,
+    } as Page;
+    let calls = 0;
+    const extension = fakeExtension({
+      pages: async () => calls++ === 0 ? [] : calls < 3 ? [page] : [],
+    });
+
+    expect(await waitForExtensionOwnedPage(extension, "/sidepanel.html", {
+      timeout: 500,
+      interval: 1,
+    })).toBe(page);
+    await expect(waitForExtensionPageClosed(extension, page, {
+      timeout: 500,
+      interval: 1,
+    })).resolves.toBeUndefined();
+  });
+
+  it("closes the native side panel through the extension worker", async () => {
+    const evaluate = vi.fn(async () => {});
+    const worker = { evaluate } as unknown as WebWorker;
+
+    await closeExtensionSidePanel(worker, { windowId: 7 });
+
+    expect(evaluate).toHaveBeenCalledOnce();
+    expect(evaluate.mock.calls[0]?.[1]).toBe(7);
+  });
+
+  it("treats an already-closed extension page as successfully closed", async () => {
+    const pages = vi.fn(async () => []);
+    const extension = fakeExtension({ pages });
+    const page = {
+      isClosed: () => true,
+      url: () => { throw new Error("target gone"); },
+    } as unknown as Page;
+
+    await expect(waitForExtensionPageClosed(extension, page)).resolves.toBeUndefined();
+    expect(pages).not.toHaveBeenCalled();
+  });
+
+  it("does not confuse a different Page wrapper for a closed target", async () => {
+    const target = {} as Target;
+    const original = {
+      isClosed: () => false,
+      url: () => "chrome-extension://abc123/sidepanel.html",
+      target: () => target,
+    } as Page;
+    const secondWrapper = {
+      isClosed: () => false,
+      url: () => "chrome-extension://abc123/sidepanel.html",
+      target: () => target,
+    } as Page;
+    const extension = fakeExtension({ pages: async () => [secondWrapper] });
+
+    await expect(waitForExtensionPageClosed(extension, original, {
+      timeout: 5,
+      interval: 1,
+    })).rejects.toThrow("Timed out");
+  });
+
+  it("forwards discovery wait options through triggerExtensionAction", async () => {
+    const page = { browser: () => fakeBrowser([]) } as unknown as Page;
+
+    await expect(triggerExtensionAction(page, undefined, { timeout: 0 })).rejects.toThrow(
+      "within 0ms",
+    );
+  });
+});

--- a/packages/browser/src/chrome-extension/actions.ts
+++ b/packages/browser/src/chrome-extension/actions.ts
@@ -1,0 +1,229 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Browser, Extension, Page, WebWorker } from "puppeteer-core";
+
+export interface InstalledExtensionSelector {
+  id?: string;
+  name?: string;
+  path?: string;
+}
+
+export interface InstalledExtensionWaitOptions {
+  timeout?: number;
+  interval?: number;
+}
+
+/** Return a loaded Puppeteer Extension, with clear ambiguity/not-found errors. */
+export async function getInstalledExtension(
+  browser: Browser,
+  selector?: string | InstalledExtensionSelector,
+  options: InstalledExtensionWaitOptions = {},
+): Promise<Extension> {
+  if (typeof selector === "string" && selector.trim() === "") {
+    throw new Error("Chrome extension id must not be empty.");
+  }
+  const extensionsMethod = (browser as Browser & {
+    extensions?: () => Promise<Map<string, Extension>>;
+  }).extensions;
+  if (typeof extensionsMethod !== "function") {
+    throw new Error(
+      "This Puppeteer runtime does not expose browser.extensions(); use puppeteer-core >= 24.41.0.",
+    );
+  }
+
+  const normalized = typeof selector === "string" ? { id: selector } : selector;
+  const effectiveSelector = normalized && Object.values(normalized).some(
+    (value) => value !== undefined,
+  ) ? normalized : undefined;
+  const timeout = options.timeout ?? 10_000;
+  const interval = options.interval ?? 50;
+  const deadline = Date.now() + timeout;
+  let loadedCount = 0;
+
+  do {
+    const extensions = [...(await extensionsMethod.call(browser)).values()];
+    loadedCount = extensions.length;
+    const matches = effectiveSelector
+      ? extensions.filter((extension) => matchesExtension(extension, effectiveSelector))
+      : extensions;
+
+    if (matches.length === 1) return matches[0]!;
+    if (!effectiveSelector && extensions.length > 1) {
+      throw new Error(
+        `${extensions.length} Chrome extensions are loaded; select one by id, name, or path.`,
+      );
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple loaded Chrome extensions matched ${JSON.stringify(effectiveSelector)}; select one by id, name, or path.`,
+      );
+    }
+    if (Date.now() >= deadline) break;
+    await delay(interval);
+  } while (true);
+
+  if (!effectiveSelector && loadedCount === 0) {
+    throw new Error(`No Chrome extensions loaded within ${timeout}ms.`);
+  }
+  throw new Error(
+    `No loaded Chrome extension matched ${JSON.stringify(effectiveSelector)} within ${timeout}ms.`,
+  );
+}
+
+/** Simulate the extension toolbar action for a real browser page. */
+export async function triggerExtensionAction(
+  page: Page,
+  selector?: string | InstalledExtensionSelector,
+  options: InstalledExtensionWaitOptions = {},
+): Promise<Extension> {
+  const extension = await getInstalledExtension(page.browser(), selector, options);
+  if (typeof extension.triggerAction !== "function") {
+    throw new Error(
+      "This Puppeteer runtime does not expose Extension.triggerAction(); use puppeteer-core >= 24.41.0.",
+    );
+  }
+  await extension.triggerAction(page);
+  return extension;
+}
+
+/** Wait until an active extension-owned page matches a manifest-relative path. */
+export async function waitForExtensionOwnedPage(
+  extension: Extension,
+  path: string,
+  options: { timeout?: number; interval?: number } = {},
+): Promise<Page> {
+  const normalizedPath = decodePath(path.replace(/^\/+/, "").split(/[?#]/, 1)[0]!);
+  const timeout = options.timeout ?? 10_000;
+  const interval = options.interval ?? 50;
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() <= deadline) {
+    const page = (await extension.pages()).find(
+      (candidate) => safeExtensionPagePath(candidate) === normalizedPath,
+    );
+    if (page) return page;
+    await delay(interval);
+  }
+  throw new Error(
+    `Timed out after ${timeout}ms waiting for extension page: ${normalizedPath}`,
+  );
+}
+
+/** Wait until an extension-owned page is no longer active. */
+export async function waitForExtensionPageClosed(
+  extension: Extension,
+  page: Page,
+  options: { timeout?: number; interval?: number } = {},
+): Promise<void> {
+  if (page.isClosed()) return;
+  let url: string;
+  try {
+    url = page.url();
+  } catch {
+    return;
+  }
+  const path = extensionPath(url);
+  if (path === undefined) {
+    throw new Error(`Page is not owned by a Chrome extension: ${url}`);
+  }
+  const timeout = options.timeout ?? 10_000;
+  const interval = options.interval ?? 50;
+  const deadline = Date.now() + timeout;
+  const target = page.target();
+
+  while (Date.now() <= deadline) {
+    const stillOpen = !page.isClosed() && (await extension.pages()).some(
+      (candidate) => candidate === page || candidate.target() === target,
+    );
+    if (!stillOpen) return;
+    await delay(interval);
+  }
+  throw new Error(
+    `Timed out after ${timeout}ms waiting for extension page to close: ${path}`,
+  );
+}
+
+/**
+ * Close the native Chrome side panel from an extension service worker.
+ * `chrome.sidePanel.close()` is available in Chrome 141 and newer.
+ */
+export async function closeExtensionSidePanel(
+  worker: WebWorker,
+  options: { windowId?: number } = {},
+): Promise<void> {
+  await worker.evaluate(async (requestedWindowId: number | undefined) => {
+    type ChromeApi = {
+      sidePanel?: { close?: (options: { windowId: number }) => Promise<void> };
+      tabs?: {
+        query?: (queryInfo: { active: boolean; currentWindow: boolean }) => Promise<Array<{
+          windowId?: number;
+        }>>;
+      };
+    };
+    const chromeApi = (globalThis as unknown as { chrome?: ChromeApi }).chrome;
+    if (typeof chromeApi?.sidePanel?.close !== "function") {
+      throw new Error(
+        "chrome.sidePanel.close() is unavailable; native side-panel closing requires Chrome 141 or newer.",
+      );
+    }
+
+    let windowId = requestedWindowId;
+    if (windowId === undefined) {
+      const tabs = await chromeApi.tabs?.query?.({ active: true, currentWindow: true });
+      windowId = tabs?.[0]?.windowId;
+    }
+    if (windowId === undefined) {
+      throw new Error("Could not resolve the Chrome window containing the side panel.");
+    }
+    await chromeApi.sidePanel.close({ windowId });
+  }, options.windowId);
+}
+
+function matchesExtension(
+  extension: Extension,
+  selector: InstalledExtensionSelector,
+): boolean {
+  return (
+    (selector.id === undefined || extension.id === selector.id) &&
+    (selector.name === undefined || extension.name === selector.name) &&
+    (selector.path === undefined || canonicalPath(extension.path) === canonicalPath(selector.path))
+  );
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function extensionPath(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "chrome-extension:") return undefined;
+    return decodePath(parsed.pathname.replace(/^\/+/, ""));
+  } catch {
+    return undefined;
+  }
+}
+
+function safeExtensionPagePath(page: Page): string | undefined {
+  try {
+    return extensionPath(page.url());
+  } catch {
+    return undefined;
+  }
+}
+
+function decodePath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}

--- a/packages/browser/src/chrome-extension/fixtures/extension/background.js
+++ b/packages/browser/src/chrome-extension/fixtures/extension/background.js
@@ -1,0 +1,1 @@
+chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });

--- a/packages/browser/src/chrome-extension/fixtures/extension/content.js
+++ b/packages/browser/src/chrome-extension/fixtures/extension/content.js
@@ -1,0 +1,7 @@
+window.addEventListener("message", (event) => {
+  if (event.source !== window || event.data?.__fixture !== "ping") return;
+  window.postMessage({ __fixture: "response", id: event.data.id }, "*");
+});
+
+document.documentElement.dataset.extensionReady = "true";
+window.postMessage({ __fixture: "ready", version: "1.0.0" }, "*");

--- a/packages/browser/src/chrome-extension/fixtures/extension/manifest.json
+++ b/packages/browser/src/chrome-extension/fixtures/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Glubean Extension Fixture",
+  "version": "1.0.0",
+  "options_ui": { "page": "options.html", "open_in_tab": true },
+  "side_panel": { "default_path": "sidepanel.html" },
+  "permissions": ["sidePanel", "tabs"],
+  "content_scripts": [
+    {
+      "matches": ["http://127.0.0.1/*"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "background": { "service_worker": "background.js" },
+  "action": {}
+}

--- a/packages/browser/src/chrome-extension/fixtures/extension/options.html
+++ b/packages/browser/src/chrome-extension/fixtures/extension/options.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Fixture Options</title></head>
+  <body>
+    <main data-testid="options-root">
+      <h1>Fixture options</h1>
+      <label>Enabled <input id="enabled" type="checkbox"></label>
+    </main>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/packages/browser/src/chrome-extension/fixtures/extension/options.js
+++ b/packages/browser/src/chrome-extension/fixtures/extension/options.js
@@ -1,0 +1,3 @@
+document.querySelector("#enabled")?.addEventListener("change", (event) => {
+  document.documentElement.dataset.enabled = String(event.target.checked);
+});

--- a/packages/browser/src/chrome-extension/fixtures/extension/sidepanel.html
+++ b/packages/browser/src/chrome-extension/fixtures/extension/sidepanel.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Fixture Side Panel</title></head>
+  <body>
+    <main data-testid="sidepanel-root"><h1>Fixture side panel</h1></main>
+    <script src="sidepanel.js"></script>
+  </body>
+</html>

--- a/packages/browser/src/chrome-extension/fixtures/extension/sidepanel.js
+++ b/packages/browser/src/chrome-extension/fixtures/extension/sidepanel.js
@@ -1,0 +1,1 @@
+document.documentElement.dataset.surface = "sidepanel";

--- a/packages/browser/src/chrome-extension/index.ts
+++ b/packages/browser/src/chrome-extension/index.ts
@@ -1,0 +1,48 @@
+export {
+  resolveExtensionPagePath,
+  resolveUnpackedExtension,
+  resolveUnpackedExtensions,
+} from "./manifest.js";
+export type {
+  ChromeExtensionManifest,
+  ExtensionPageKind,
+  UnpackedExtension,
+} from "./manifest.js";
+
+export { extensionLaunchOptions } from "./launch.js";
+export type { ExtensionLaunchOverrides } from "./launch.js";
+
+export { createExtensionTest } from "./test.js";
+export type { ChromeExtensionTestOptions } from "./test.js";
+
+export {
+  extensionPageUrl,
+  findExtensionTarget,
+  listExtensionTargets,
+  parseExtensionUrl,
+  waitForExtensionPage,
+  waitForExtensionTarget,
+  waitForExtensionWorker,
+} from "./targets.js";
+export type {
+  ExtensionPageInfo,
+  ExtensionTargetInfo,
+  ExtensionTargetSelector,
+  ExtensionTargetType,
+  ExtensionWorkerInfo,
+} from "./targets.js";
+
+export { installExtensionReadyWatcher } from "./ready.js";
+export type { ExtensionReadyEvent, ExtensionReadyWatcher } from "./ready.js";
+
+export {
+  closeExtensionSidePanel,
+  getInstalledExtension,
+  triggerExtensionAction,
+  waitForExtensionOwnedPage,
+  waitForExtensionPageClosed,
+} from "./actions.js";
+export type {
+  InstalledExtensionSelector,
+  InstalledExtensionWaitOptions,
+} from "./actions.js";

--- a/packages/browser/src/chrome-extension/launch.test.ts
+++ b/packages/browser/src/chrome-extension/launch.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { extensionLaunchOptions } from "./launch.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
+
+describe("extensionLaunchOptions", () => {
+  it("loads unpacked extensions and defaults to visible Chrome", () => {
+    expect(extensionLaunchOptions(fixture, {
+      userDataDir: ".tmp/extension-profile",
+    })).toMatchObject({
+      headless: false,
+      pipe: true,
+      userDataDir: ".tmp/extension-profile",
+      enableExtensions: [fixture],
+    });
+  });
+
+  it("allows an explicit headless mode", () => {
+    expect(extensionLaunchOptions(fixture, { headless: true }).headless).toBe(true);
+  });
+
+  it("rejects an incompatible pipe mode", () => {
+    expect(() => extensionLaunchOptions(fixture, { pipe: false })).toThrow(
+      "requires pipe: true",
+    );
+  });
+
+  it("rejects caller-owned remote debugging args", () => {
+    expect(() => extensionLaunchOptions(fixture, {
+      args: ["--remote-debugging-port=9222"],
+    })).toThrow("Puppeteer owns the required pipe transport");
+  });
+});

--- a/packages/browser/src/chrome-extension/launch.ts
+++ b/packages/browser/src/chrome-extension/launch.ts
@@ -1,0 +1,35 @@
+import type { LaunchOptions } from "puppeteer-core";
+import { resolveUnpackedExtensions } from "./manifest.js";
+
+/** Launch options accepted by Puppeteer, excluding its extension switch. */
+export type ExtensionLaunchOverrides = Omit<LaunchOptions, "enableExtensions">;
+
+/**
+ * Build Puppeteer launch options for one or more unpacked extensions.
+ *
+ * Puppeteer's extension transport requires `pipe: true`. Visible Chrome is the
+ * default because toolbar actions and native side panels are user-facing UI;
+ * callers may opt into headless mode explicitly for compatible surfaces.
+ */
+export function extensionLaunchOptions(
+  extensionPaths: string | readonly string[],
+  overrides: ExtensionLaunchOverrides = {},
+): LaunchOptions {
+  if (overrides.pipe === false) {
+    throw new Error(
+      "Puppeteer requires pipe: true when loading unpacked Chrome extensions with enableExtensions.",
+    );
+  }
+  if (overrides.args?.some((arg) => arg.startsWith("--remote-debugging-"))) {
+    throw new Error(
+      "Do not set --remote-debugging-port or --remote-debugging-pipe in extension launch args; Puppeteer owns the required pipe transport.",
+    );
+  }
+  const extensions = resolveUnpackedExtensions(extensionPaths);
+  return {
+    ...overrides,
+    headless: overrides.headless ?? false,
+    pipe: true,
+    enableExtensions: extensions.map((extension) => extension.path),
+  };
+}

--- a/packages/browser/src/chrome-extension/manifest.test.ts
+++ b/packages/browser/src/chrome-extension/manifest.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  resolveExtensionPagePath,
+  resolveUnpackedExtension,
+  resolveUnpackedExtensions,
+} from "./manifest.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
+
+describe("resolveUnpackedExtension", () => {
+  it("resolves a directory and reads its manifest", () => {
+    const extension = resolveUnpackedExtension(fixture);
+
+    expect(extension.path).toBe(fixture);
+    expect(extension.manifestPath).toBe(join(fixture, "manifest.json"));
+    expect(extension.manifest.name).toBe("Glubean Extension Fixture");
+    expect(extension.manifest.manifest_version).toBe(3);
+  });
+
+  it("accepts one or more extension directories and deduplicates them", () => {
+    expect(resolveUnpackedExtensions(fixture)).toHaveLength(1);
+    expect(resolveUnpackedExtensions([fixture, fixture])).toHaveLength(1);
+  });
+
+  it("deduplicates the same extension reached through a symlink", () => {
+    const tempDirectory = mkdtempSync(join(tmpdir(), "glubean-extension-manifest-"));
+    const linkedPath = join(tempDirectory, "extension-link");
+    symlinkSync(fixture, linkedPath, process.platform === "win32" ? "junction" : "dir");
+    try {
+      expect(resolveUnpackedExtensions([fixture, linkedPath])).toHaveLength(1);
+    } finally {
+      rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("fails before launch when the directory is invalid", () => {
+    expect(() => resolveUnpackedExtension(join(fixture, "missing"))).toThrow(
+      "does not exist",
+    );
+    expect(() => resolveUnpackedExtensions([])).toThrow(
+      "At least one Chrome extension directory is required",
+    );
+  });
+
+  it("resolves options and side panel paths from the manifest", () => {
+    const extension = resolveUnpackedExtension(fixture);
+
+    expect(resolveExtensionPagePath(extension, "options")).toBe("options.html");
+    expect(resolveExtensionPagePath(extension, "sidepanel")).toBe("sidepanel.html");
+  });
+});

--- a/packages/browser/src/chrome-extension/manifest.ts
+++ b/packages/browser/src/chrome-extension/manifest.ts
@@ -1,0 +1,118 @@
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export interface ChromeExtensionManifest {
+  manifest_version: 2 | 3;
+  name: string;
+  version: string;
+  options_page?: string;
+  options_ui?: {
+    page?: string;
+    open_in_tab?: boolean;
+    [key: string]: unknown;
+  };
+  action?: {
+    default_popup?: string;
+    [key: string]: unknown;
+  };
+  background?: {
+    service_worker?: string;
+    page?: string;
+    scripts?: string[];
+    [key: string]: unknown;
+  };
+  side_panel?: {
+    default_path?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface UnpackedExtension {
+  path: string;
+  manifestPath: string;
+  manifest: ChromeExtensionManifest;
+}
+
+/** Resolve and validate a Chrome unpacked extension directory. */
+export function resolveUnpackedExtension(extensionPath: string): UnpackedExtension {
+  if (!extensionPath.trim()) {
+    throw new Error("Chrome extension path must not be empty.");
+  }
+
+  const requestedPath = resolve(extensionPath);
+  let stats: ReturnType<typeof statSync>;
+  try {
+    stats = statSync(requestedPath);
+  } catch {
+    throw new Error(`Chrome extension directory does not exist: ${requestedPath}`);
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`Chrome extension path is not a directory: ${requestedPath}`);
+  }
+  const path = realpathSync(requestedPath);
+
+  const manifestPath = join(path, "manifest.json");
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as unknown;
+  } catch {
+    throw new Error(`Chrome extension manifest.json is missing or invalid: ${manifestPath}`);
+  }
+
+  if (!isChromeExtensionManifest(manifest)) {
+    throw new Error(
+      `Chrome extension manifest.json must declare manifest_version (2 or 3), name, and version: ${manifestPath}`,
+    );
+  }
+
+  return { path, manifestPath, manifest };
+}
+
+export function resolveUnpackedExtensions(
+  extensionPaths: string | readonly string[],
+): UnpackedExtension[] {
+  const paths = typeof extensionPaths === "string" ? [extensionPaths] : extensionPaths;
+  if (paths.length === 0) {
+    throw new Error("At least one Chrome extension directory is required.");
+  }
+  const extensions = paths.map(resolveUnpackedExtension);
+  return [...new Map(
+    extensions.map((extension) => [extension.path, extension]),
+  ).values()];
+}
+
+export type ExtensionPageKind = "options" | "sidepanel";
+
+/** Resolve an options or side-panel HTML path declared by the manifest. */
+export function resolveExtensionPagePath(
+  extension: UnpackedExtension,
+  kind: ExtensionPageKind,
+): string {
+  const path = kind === "options"
+    ? extension.manifest.options_ui?.page ?? extension.manifest.options_page
+    : extension.manifest.side_panel?.default_path;
+
+  if (typeof path !== "string" || path.trim() === "") {
+    const declaration = kind === "options"
+      ? "options_ui.page or options_page"
+      : "side_panel.default_path";
+    throw new Error(
+      `Chrome extension manifest does not declare ${declaration}: ${extension.manifestPath}`,
+    );
+  }
+
+  return path.replace(/^\/+/, "");
+}
+
+function isChromeExtensionManifest(value: unknown): value is ChromeExtensionManifest {
+  if (!value || typeof value !== "object") return false;
+  const manifest = value as Record<string, unknown>;
+  return (
+    (manifest.manifest_version === 2 || manifest.manifest_version === 3) &&
+    typeof manifest.name === "string" &&
+    manifest.name.length > 0 &&
+    typeof manifest.version === "string" &&
+    manifest.version.length > 0
+  );
+}

--- a/packages/browser/src/chrome-extension/ready.test.ts
+++ b/packages/browser/src/chrome-extension/ready.test.ts
@@ -1,0 +1,32 @@
+import type { JSHandle, Page } from "puppeteer-core";
+import { describe, expect, it, vi } from "vitest";
+import { installExtensionReadyWatcher } from "./ready.js";
+
+describe("installExtensionReadyWatcher", () => {
+  it("returns the ready envelope rather than the predicate boolean", async () => {
+    const envelope = { key: "__fixture", version: "1.0.0" };
+    const dispose = vi.fn(async () => {});
+    let predicate: ((markerName: string) => unknown) | undefined;
+    const page = {
+      evaluateOnNewDocument: vi.fn(async () => ({ identifier: "script-id" })),
+      removeScriptToEvaluateOnNewDocument: vi.fn(async () => {}),
+      evaluate: vi.fn(async () => {}),
+      waitForFunction: vi.fn(async (candidate: (markerName: string) => unknown) => {
+        predicate = candidate;
+        return {
+          jsonValue: async () => envelope,
+          dispose,
+        } as unknown as JSHandle;
+      }),
+    } as unknown as Page;
+
+    const watcher = await installExtensionReadyWatcher(page, {
+      keys: ["__fixture"],
+    });
+    expect(await watcher.wait()).toEqual(envelope);
+    expect(predicate).toBeTypeOf("function");
+    expect(dispose).toHaveBeenCalledOnce();
+    await watcher.dispose();
+    expect(page.removeScriptToEvaluateOnNewDocument).toHaveBeenCalledWith("script-id");
+  });
+});

--- a/packages/browser/src/chrome-extension/ready.ts
+++ b/packages/browser/src/chrome-extension/ready.ts
@@ -1,0 +1,84 @@
+import type { Page } from "puppeteer-core";
+
+export interface ExtensionReadyEvent {
+  key: string;
+  version?: string;
+}
+
+export interface ExtensionReadyWatcher {
+  wait(): Promise<ExtensionReadyEvent>;
+  dispose(): Promise<void>;
+}
+
+/**
+ * Install a watcher before navigation and wait for a top-level content script
+ * to post `{ [key]: "ready", version?: string }` into its matching page.
+ * Call `dispose()` when the watcher is no longer needed.
+ */
+export async function installExtensionReadyWatcher(
+  page: Page,
+  options: { keys?: readonly string[]; timeout?: number } = {},
+): Promise<ExtensionReadyWatcher> {
+  const keys = options.keys ?? ["__glubean"];
+  if (keys.length === 0) throw new Error("At least one extension ready key is required.");
+
+  const marker = `__glubeanExtensionReady_${Math.random().toString(36).slice(2)}`;
+  const script = await page.evaluateOnNewDocument(
+    (markerName: string, readyKeys: readonly string[]) => {
+      const listenerKey = `${markerName}_listener`;
+      const listener = (event: MessageEvent) => {
+        if (event.source !== window || !event.data || typeof event.data !== "object") return;
+        const data = event.data as Record<string, unknown>;
+        const key = readyKeys.find((candidate) => data[candidate] === "ready");
+        if (!key) return;
+        const record = globalThis as typeof globalThis & Record<string, unknown>;
+        record[markerName] = {
+          key,
+          version: typeof data.version === "string" ? data.version : undefined,
+        };
+      };
+      const record = globalThis as typeof globalThis & Record<string, unknown>;
+      record[listenerKey] = listener;
+      window.addEventListener("message", listener);
+    },
+    marker,
+    keys,
+  );
+
+  return {
+    async wait(): Promise<ExtensionReadyEvent> {
+      const handle = await page.waitForFunction(
+        (markerName: string) =>
+          (globalThis as Record<string, unknown>)[markerName] ?? false,
+        { timeout: options.timeout ?? 10_000 },
+        marker,
+      );
+      try {
+        return await handle.jsonValue() as unknown as ExtensionReadyEvent;
+      } finally {
+        await handle.dispose();
+      }
+    },
+    async dispose(): Promise<void> {
+      try {
+        await page.removeScriptToEvaluateOnNewDocument(script.identifier);
+      } catch {
+        // The page may already be closed.
+      }
+      try {
+        await page.evaluate((markerName: string) => {
+          const record = globalThis as typeof globalThis & Record<string, unknown>;
+          const listenerKey = `${markerName}_listener`;
+          const listener = record[listenerKey];
+          if (typeof listener === "function") {
+            window.removeEventListener("message", listener as EventListener);
+          }
+          delete record[listenerKey];
+          delete record[markerName];
+        }, marker);
+      } catch {
+        // The page may have closed or navigated while cleanup was requested.
+      }
+    },
+  };
+}

--- a/packages/browser/src/chrome-extension/smoke.test.ts
+++ b/packages/browser/src/chrome-extension/smoke.test.ts
@@ -1,0 +1,111 @@
+import { createServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { resolveTemplate, type GlubeanRuntime } from "@glubean/sdk";
+import type { BrowserTestContext } from "../page.js";
+import { browser } from "../plugin.js";
+import {
+  closeExtensionSidePanel,
+  getInstalledExtension,
+  triggerExtensionAction,
+  waitForExtensionOwnedPage,
+  waitForExtensionPageClosed,
+} from "./actions.js";
+import { installExtensionReadyWatcher } from "./ready.js";
+import { extensionPageUrl, waitForExtensionWorker } from "./targets.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
+const runSmoke =
+  process.env.GLUBEAN_CHROME_EXTENSION_SMOKE === "1" ||
+  process.env.npm_lifecycle_event === "test:chrome-extension:smoke";
+
+function makeRuntime(): GlubeanRuntime {
+  return {
+    vars: {},
+    secrets: {},
+    http: {} as GlubeanRuntime["http"],
+    requireVar: (key) => { throw new Error(`Missing required variable: ${key}`); },
+    requireSecret: (key) => { throw new Error(`Missing required secret: ${key}`); },
+    resolveTemplate: (template) => resolveTemplate(template, {}, {}),
+    action: () => {},
+    trace: () => {},
+    event: () => {},
+    log: () => {},
+  };
+}
+
+const context: BrowserTestContext = {
+  testId: "chrome-extension-real-smoke",
+  action: () => {},
+  event: () => {},
+  trace: () => {},
+  metric: () => {},
+  log: () => {},
+  warn: () => {},
+};
+
+describe.skipIf(!runSmoke)("real Chrome extension smoke", () => {
+  let fixtureUrl = "";
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end("<!doctype html><html><body><main>Content fixture</main></body></html>");
+  });
+
+  beforeAll(async () => {
+    await new Promise<void>((resolvePromise, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolvePromise());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Fixture server has no TCP port.");
+    fixtureUrl = `http://127.0.0.1:${address.port}/fixture`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolvePromise, reject) => {
+      server.close((error) => error ? reject(error) : resolvePromise());
+    });
+  });
+
+  it("loads options, content script, and native side-panel open/close", async () => {
+    const chrome = browser({ launch: true, extensions: fixture }).create(makeRuntime());
+    const page = await chrome.newPage(context);
+
+    try {
+      const extension = await getInstalledExtension(page.raw.browser());
+      expect(extension.path).toBe(fixture);
+      await page.goto(extensionPageUrl(extension.id, "options.html"), {
+        waitUntil: "domcontentloaded",
+      });
+      expect(await page.title()).toBe("Fixture Options");
+      await page.click("#enabled");
+      expect(await page.raw.$eval(
+        "html",
+        (element) => element.dataset.enabled,
+      )).toBe("true");
+
+      const ready = await installExtensionReadyWatcher(page.raw, {
+        keys: ["__fixture"],
+      });
+      await page.goto(fixtureUrl, { waitUntil: "domcontentloaded" });
+      expect(await ready.wait()).toEqual({ key: "__fixture", version: "1.0.0" });
+      expect(await page.raw.$eval(
+        "html",
+        (element) => element.dataset.extensionReady,
+      )).toBe("true");
+      await ready.dispose();
+
+      await triggerExtensionAction(page.raw, extension.id);
+      const sidePanel = await waitForExtensionOwnedPage(extension, "sidepanel.html");
+      await sidePanel.waitForSelector("[data-testid=sidepanel-root]");
+      expect(await sidePanel.title()).toBe("Fixture Side Panel");
+
+      const worker = await waitForExtensionWorker(page.raw.browser(), extension.id);
+      await closeExtensionSidePanel(worker.worker);
+      await waitForExtensionPageClosed(extension, sidePanel);
+    } finally {
+      await page.close();
+      await chrome.close();
+    }
+  }, 30_000);
+});

--- a/packages/browser/src/chrome-extension/targets.test.ts
+++ b/packages/browser/src/chrome-extension/targets.test.ts
@@ -1,0 +1,99 @@
+import type { Browser, Page, Target, WebWorker } from "puppeteer-core";
+import { describe, expect, it } from "vitest";
+import {
+  extensionPageUrl,
+  findExtensionTarget,
+  listExtensionTargets,
+  parseExtensionUrl,
+  waitForExtensionPage,
+  waitForExtensionWorker,
+} from "./targets.js";
+
+function target(
+  url: string,
+  type: string,
+  options: { page?: Page; worker?: WebWorker } = {},
+): Target {
+  return {
+    url: () => url,
+    type: () => type,
+    page: async () => options.page ?? null,
+    worker: async () => options.worker ?? null,
+  } as unknown as Target;
+}
+
+function browserWithTargets(targets: Target[]): Browser {
+  return { targets: () => targets } as unknown as Browser;
+}
+
+describe("extension target helpers", () => {
+  it("parses extension URLs and builds extension page URLs", () => {
+    expect(parseExtensionUrl("chrome-extension://abc123/popup.html")).toEqual({
+      id: "abc123",
+      path: "popup.html",
+    });
+    expect(parseExtensionUrl("https://example.test")).toBeNull();
+    expect(extensionPageUrl("abc123", "/popup.html")).toBe(
+      "chrome-extension://abc123/popup.html",
+    );
+    expect(parseExtensionUrl(
+      "chrome-extension://abc123/options.html?tab=privacy#/advanced",
+    )).toEqual({ id: "abc123", path: "options.html" });
+    expect(parseExtensionUrl(
+      "chrome-extension://abc123/side%20panel-%E8%AF%AD%E8%A8%80.html",
+    )).toEqual({ id: "abc123", path: "side panel-语言.html" });
+  });
+
+  it("lists only Chrome extension targets", () => {
+    const extensionTarget = target(
+      "chrome-extension://abc123/background.js",
+      "service_worker",
+    );
+    const browser = browserWithTargets([
+      extensionTarget,
+      target("https://example.test/", "page"),
+    ]);
+
+    expect(listExtensionTargets(browser)).toMatchObject([{
+      id: "abc123",
+      path: "background.js",
+      type: "service_worker",
+    }]);
+    expect(findExtensionTarget(browser, "abc123")?.target).toBe(extensionTarget);
+  });
+
+  it("returns a live worker", async () => {
+    const worker = {} as WebWorker;
+    const browser = browserWithTargets([
+      target("chrome-extension://abc123/background.js", "service_worker", { worker }),
+    ]);
+
+    expect((await waitForExtensionWorker(browser, "abc123")).worker).toBe(worker);
+  });
+
+  it("accepts background-page and webview page target types", async () => {
+    const page = {} as Page;
+    const browser = browserWithTargets([
+      target("chrome-extension://abc123/background.html", "background_page", { page }),
+    ]);
+
+    const result = await waitForExtensionPage(browser, {
+      id: "abc123",
+      path: "/background.html",
+    });
+    expect(result.type).toBe("background_page");
+    expect(result.page).toBe(page);
+  });
+
+  it("matches manifest paths when the live page has query or hash state", async () => {
+    const page = {} as Page;
+    const browser = browserWithTargets([
+      target("chrome-extension://abc123/sidepanel.html?tab=4#/", "page", { page }),
+    ]);
+
+    expect((await waitForExtensionPage(browser, {
+      id: "abc123",
+      path: "sidepanel.html",
+    })).page).toBe(page);
+  });
+});

--- a/packages/browser/src/chrome-extension/targets.ts
+++ b/packages/browser/src/chrome-extension/targets.ts
@@ -1,0 +1,190 @@
+import type { Browser, Page, Target, WebWorker } from "puppeteer-core";
+
+const EXTENSION_URL_PREFIX = "chrome-extension://";
+
+export type ExtensionTargetType =
+  | "page"
+  | "background_page"
+  | "service_worker"
+  | "shared_worker"
+  | "webview"
+  | "other";
+
+export interface ExtensionTargetSelector {
+  id?: string;
+  path?: string;
+  type?: ExtensionTargetType;
+}
+
+export interface ExtensionTargetInfo {
+  id: string;
+  path: string;
+  url: string;
+  type: ExtensionTargetType;
+  target: Target;
+}
+
+export interface ExtensionWorkerInfo extends ExtensionTargetInfo {
+  type: "service_worker" | "shared_worker";
+  worker: WebWorker;
+}
+
+export interface ExtensionPageInfo extends ExtensionTargetInfo {
+  type: "page" | "background_page" | "webview";
+  page: Page;
+}
+
+export function extensionPageUrl(id: string, path = ""): string {
+  const normalizedId = id.trim();
+  if (!normalizedId) throw new Error("Chrome extension id must not be empty.");
+  const normalizedPath = path.replace(/^\/+/, "");
+  return `${EXTENSION_URL_PREFIX}${normalizedId}/${normalizedPath}`;
+}
+
+export function parseExtensionUrl(url: string): { id: string; path: string } | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "chrome-extension:" || !parsed.hostname) return null;
+    return {
+      id: parsed.hostname,
+      path: decodePath(parsed.pathname.replace(/^\/+/, "")),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function listExtensionTargets(browser: Browser): ExtensionTargetInfo[] {
+  return browser.targets().flatMap((target) => {
+    const info = toExtensionTargetInfo(target);
+    return info ? [info] : [];
+  });
+}
+
+export function findExtensionTarget(
+  browser: Browser,
+  selector: string | ExtensionTargetSelector,
+): ExtensionTargetInfo | undefined {
+  const normalized = normalizeSelector(selector);
+  return listExtensionTargets(browser).find((info) => matches(info, normalized));
+}
+
+export async function waitForExtensionTarget(
+  browser: Browser,
+  selector: string | ExtensionTargetSelector,
+  options: { timeout?: number } = {},
+): Promise<ExtensionTargetInfo> {
+  const normalized = normalizeSelector(selector);
+  const existing = findExtensionTarget(browser, normalized);
+  if (existing) return existing;
+
+  const target = await browser.waitForTarget((candidate) => {
+    const info = toExtensionTargetInfo(candidate);
+    return info ? matches(info, normalized) : false;
+  }, options);
+
+  const info = toExtensionTargetInfo(target);
+  if (!info) {
+    throw new Error("Puppeteer returned a non-extension target while waiting for an extension target.");
+  }
+  return info;
+}
+
+export async function waitForExtensionWorker(
+  browser: Browser,
+  selector: string | Omit<ExtensionTargetSelector, "type">,
+  options: { timeout?: number } = {},
+): Promise<ExtensionWorkerInfo> {
+  const normalized = normalizeSelector(selector);
+  const existing = listExtensionTargets(browser).find(
+    (info) => isWorkerType(info.type) && matches(info, normalized),
+  );
+  const target = existing?.target ?? await browser.waitForTarget((candidate) => {
+    const info = toExtensionTargetInfo(candidate);
+    return info ? isWorkerType(info.type) && matches(info, normalized) : false;
+  }, options);
+  const info = toExtensionTargetInfo(target);
+  if (!info || !isWorkerType(info.type)) {
+    throw new Error("Puppeteer returned a non-worker target while waiting for an extension worker.");
+  }
+  const worker = await target.worker();
+  if (!worker) {
+    throw new Error(`Extension worker target is no longer available: ${target.url()}`);
+  }
+  return { ...info, type: info.type, worker };
+}
+
+export async function waitForExtensionPage(
+  browser: Browser,
+  selector: string | Omit<ExtensionTargetSelector, "type">,
+  options: { timeout?: number } = {},
+): Promise<ExtensionPageInfo> {
+  const normalized = normalizeSelector(selector);
+  const existing = listExtensionTargets(browser).find(
+    (info) => isPageType(info.type) && matches(info, normalized),
+  );
+  const target = existing?.target ?? await browser.waitForTarget((candidate) => {
+    const info = toExtensionTargetInfo(candidate);
+    return info ? isPageType(info.type) && matches(info, normalized) : false;
+  }, options);
+  const info = toExtensionTargetInfo(target);
+  if (!info || !isPageType(info.type)) {
+    throw new Error("Puppeteer returned a non-page target while waiting for an extension page.");
+  }
+  const page = await target.page();
+  if (!page) throw new Error(`Extension page target is no longer available: ${info.url}`);
+  return { ...info, type: info.type, page };
+}
+
+function normalizeSelector(
+  selector: string | ExtensionTargetSelector,
+): ExtensionTargetSelector {
+  return typeof selector === "string" ? { id: selector } : selector;
+}
+
+function matches(info: ExtensionTargetInfo, selector: ExtensionTargetSelector): boolean {
+  return (
+    (selector.id === undefined || selector.id === info.id) &&
+    (selector.path === undefined || normalizePath(selector.path) === info.path) &&
+    (selector.type === undefined || selector.type === info.type)
+  );
+}
+
+function normalizePath(path: string): string {
+  return decodePath(path.replace(/^\/+/, "").split(/[?#]/, 1)[0]!);
+}
+
+function decodePath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function isExtensionTargetType(type: string): type is ExtensionTargetType {
+  return [
+    "page",
+    "background_page",
+    "service_worker",
+    "shared_worker",
+    "webview",
+    "other",
+  ].includes(type);
+}
+
+function isWorkerType(type: ExtensionTargetType): type is "service_worker" | "shared_worker" {
+  return type === "service_worker" || type === "shared_worker";
+}
+
+function isPageType(type: ExtensionTargetType): type is "page" | "background_page" | "webview" {
+  return type === "page" || type === "background_page" || type === "webview";
+}
+
+function toExtensionTargetInfo(target: Target): ExtensionTargetInfo | null {
+  const url = target.url();
+  const parsed = parseExtensionUrl(url);
+  const type = target.type() as string;
+  if (!parsed || !isExtensionTargetType(type)) return null;
+  return { id: parsed.id, path: parsed.path, url, type, target };
+}

--- a/packages/browser/src/chrome-extension/test.test.ts
+++ b/packages/browser/src/chrome-extension/test.test.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { createExtensionTest } from "./test.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
+
+describe("createExtensionTest", () => {
+  it("creates a runnable browser test with a page fixture", () => {
+    const setup = createExtensionTest({ extensions: fixture });
+
+    expect(setup.test).toHaveProperty("extend");
+    expect(setup.chrome).toBeDefined();
+  });
+});

--- a/packages/browser/src/chrome-extension/test.ts
+++ b/packages/browser/src/chrome-extension/test.ts
@@ -1,0 +1,35 @@
+import { configure, test as baseTest, type ExtensionFn } from "@glubean/sdk";
+import type { BrowserOptions, BrowserTestContext, InstrumentedPage } from "../page.js";
+import { browser } from "../plugin.js";
+
+export type ChromeExtensionTestOptions = Omit<
+  Extract<BrowserOptions, { launch: true }>,
+  "launch" | "extensions"
+> & {
+  extensions: string | readonly string[];
+};
+
+/** Create a Glubean test with a fresh instrumented page and loaded extensions. */
+export function createExtensionTest(options: ChromeExtensionTestOptions) {
+  const { chrome } = configure({
+    plugins: {
+      chrome: browser({ ...options, launch: true }),
+    },
+  });
+  const pageFixture: ExtensionFn<InstrumentedPage> = async (ctx, use) => {
+    const page = await chrome.newPage(ctx as unknown as BrowserTestContext);
+    try {
+      await use(page);
+    } catch (error) {
+      await page.screenshotOnFailure();
+      throw error;
+    } finally {
+      await page.close();
+    }
+  };
+
+  return {
+    test: baseTest.extend({ page: pageFixture }),
+    chrome,
+  };
+}

--- a/packages/browser/src/chrome.test.ts
+++ b/packages/browser/src/chrome.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, vi, afterEach } from "vitest";
-import { resolveEndpoint } from "./chrome.js";
+import type { Browser } from "puppeteer-core";
+import { launchChrome, resolveEndpoint } from "./chrome.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -87,4 +88,87 @@ test("resolveEndpoint: invalid protocol throws", async () => {
   await expect(resolveEndpoint("ftp://chrome.local")).rejects.toThrow(
     "Invalid Chrome endpoint",
   );
+});
+
+test("launchChrome awaits explicit unpacked extension installation", async () => {
+  const installExtension = vi.fn(async () => "abc123");
+  const fakeBrowser = {
+    installExtension,
+    close: vi.fn(async () => {}),
+  } as unknown as Browser;
+  const launch = vi.fn(async () => fakeBrowser);
+
+  await expect(launchChrome(
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    { launch, connect: vi.fn(async () => fakeBrowser) },
+    { pipe: true, enableExtensions: ["/tmp/extension"] },
+  )).resolves.toBe(fakeBrowser);
+
+  expect(launch).toHaveBeenCalledWith(expect.objectContaining({
+    enableExtensions: true,
+    pipe: true,
+  }));
+  expect(installExtension).toHaveBeenCalledWith("/tmp/extension");
+});
+
+test("launchChrome closes Chrome and reports an unpacked extension rejection", async () => {
+  const close = vi.fn(async () => {});
+  const fakeBrowser = {
+    installExtension: vi.fn(async () => {
+      throw new Error("manifest rejected");
+    }),
+    close,
+  } as unknown as Browser;
+
+  await expect(launchChrome(
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    {
+      launch: vi.fn(async () => fakeBrowser),
+      connect: vi.fn(async () => fakeBrowser),
+    },
+    { pipe: true, enableExtensions: ["/tmp/broken-extension"] },
+  )).rejects.toThrow(
+    "Failed to load unpacked Chrome extension at /tmp/broken-extension: manifest rejected",
+  );
+  expect(close).toHaveBeenCalledOnce();
+});
+
+test("launchChrome rejects extension arrays without pipe transport", async () => {
+  const fakeBrowser = {} as Browser;
+  const launch = vi.fn(async () => fakeBrowser);
+
+  await expect(launchChrome(
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    { launch, connect: vi.fn(async () => fakeBrowser) },
+    { enableExtensions: ["/tmp/extension"] },
+  )).rejects.toThrow("requires launchOptions.pipe to be true");
+  expect(launch).not.toHaveBeenCalled();
+});
+
+test("launchChrome rejects direct remote-debugging args with extension arrays", async () => {
+  const fakeBrowser = {} as Browser;
+  const launch = vi.fn(async () => fakeBrowser);
+
+  await expect(launchChrome(
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    { launch, connect: vi.fn(async () => fakeBrowser) },
+    {
+      pipe: true,
+      enableExtensions: ["/tmp/extension"],
+      args: ["--remote-debugging-port=9222"],
+    },
+  )).rejects.toThrow("Puppeteer owns the required pipe transport");
+  expect(launch).not.toHaveBeenCalled();
+});
+
+test("launchChrome rejects non-string extension array entries", async () => {
+  const fakeBrowser = {} as Browser;
+  const launch = vi.fn(async () => fakeBrowser);
+
+  await expect(launchChrome(
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    { launch, connect: vi.fn(async () => fakeBrowser) },
+    { pipe: true, enableExtensions: [42] as never },
+  )).rejects.toThrow("must contain only extension directory paths");
+  expect(launch).not.toHaveBeenCalled();
 });

--- a/packages/browser/src/chrome.ts
+++ b/packages/browser/src/chrome.ts
@@ -10,7 +10,7 @@
  */
 
 import { statSync } from "node:fs";
-import puppeteerDefault, { type Browser } from "puppeteer-core";
+import puppeteerDefault, { type Browser, type LaunchOptions } from "puppeteer-core";
 import type { PuppeteerLike } from "./page.js";
 
 const WELL_KNOWN_PATHS: Record<string, string[]> = {
@@ -85,7 +85,7 @@ export async function launchChrome(
   }
 
   const pptr = puppeteerInstance ?? puppeteerDefault;
-  return await pptr.launch({
+  const mergedOptions = {
     headless: true,
     args: [
       "--no-sandbox",
@@ -95,7 +95,62 @@ export async function launchChrome(
     ],
     ...launchOptions,
     executablePath: chromePath,
-  });
+  } as LaunchOptions;
+  let extensionPaths: string[] | undefined;
+  if (Array.isArray(mergedOptions.enableExtensions)) {
+    if (!mergedOptions.enableExtensions.every(
+      (extensionPath): extensionPath is string => typeof extensionPath === "string",
+    )) {
+      throw new Error("enableExtensions must contain only extension directory paths.");
+    }
+    extensionPaths = mergedOptions.enableExtensions;
+  }
+
+  if (extensionPaths && mergedOptions.pipe !== true) {
+    throw new Error(
+      "Loading unpacked Chrome extensions requires launchOptions.pipe to be true.",
+    );
+  }
+  if (
+    extensionPaths &&
+    mergedOptions.args?.some((arg) => arg.startsWith("--remote-debugging-"))
+  ) {
+    throw new Error(
+      "Do not set --remote-debugging-port or --remote-debugging-pipe when loading extensions; Puppeteer owns the required pipe transport.",
+    );
+  }
+
+  // Puppeteer 24.43.1 starts loadUnpacked calls without correctly awaiting
+  // them when enableExtensions is an array. Enable extension debugging at
+  // launch, then install each validated path ourselves so launch resolves only
+  // after Chrome has accepted every extension.
+  if (extensionPaths) mergedOptions.enableExtensions = true;
+  const browser = await pptr.launch(mergedOptions);
+  if (!extensionPaths) return browser;
+
+  if (typeof browser.installExtension !== "function") {
+    await browser.close();
+    throw new Error(
+      "This Puppeteer runtime cannot install unpacked extensions; use puppeteer-core >= 24.41.0.",
+    );
+  }
+
+  try {
+    await Promise.all(extensionPaths.map(async (extensionPath) => {
+      try {
+        await browser.installExtension(extensionPath);
+      } catch (error) {
+        throw new Error(
+          `Failed to load unpacked Chrome extension at ${extensionPath}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+    }));
+    return browser;
+  } catch (error) {
+    try { await browser.close(); } catch { /* preserve the install error */ }
+    throw error;
+  }
 }
 
 /**

--- a/packages/browser/src/page-extension.test.ts
+++ b/packages/browser/src/page-extension.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { Browser } from "puppeteer-core";
+import { GlubeanBrowser, resolveNavigationUrl } from "./page.js";
+
+describe("extension-origin navigation", () => {
+  it("does not prepend baseUrl to chrome-extension URLs", () => {
+    expect(resolveNavigationUrl(
+      "chrome-extension://abc123/options.html",
+      "https://app.example.test",
+    )).toBe(
+      "chrome-extension://abc123/options.html",
+    );
+    expect(resolveNavigationUrl("/dashboard", "https://app.example.test")).toBe(
+      "https://app.example.test/dashboard",
+    );
+    expect(resolveNavigationUrl(
+      "data:text/plain,hello",
+      "https://app.example.test",
+    )).toBe(
+      "https://app.example.test/data:text/plain,hello",
+    );
+  });
+
+  it("rejects attach requests for pipe-transport Chrome sessions", async () => {
+    const raw = { wsEndpoint: () => "" } as unknown as Browser;
+    const chrome = new GlubeanBrowser(async () => raw, undefined, { launch: true });
+
+    await expect(chrome.wsEndpoint()).rejects.toThrow(
+      "pipe transport and has no CDP WebSocket endpoint",
+    );
+  });
+});

--- a/packages/browser/src/page.ts
+++ b/packages/browser/src/page.ts
@@ -74,8 +74,25 @@ export interface PuppeteerLike {
 export type BrowserOptions =
   & BrowserOptionsBase
   & (
-    | { launch: true; executablePath?: string; endpoint?: never }
-    | { endpoint: string; launch?: never; executablePath?: never }
+    | {
+        launch: true;
+        executablePath?: string;
+        endpoint?: never;
+        /**
+         * One or more unpacked Chrome extension directories to load.
+         * Each directory must contain a valid manifest.json.
+         *
+         * Extension launch mode uses Puppeteer's pipe transport and defaults
+         * to visible Chrome unless `launchOptions.headless` is set explicitly.
+         */
+        extensions?: string | readonly string[];
+      }
+    | {
+        endpoint: string;
+        launch?: never;
+        executablePath?: never;
+        extensions?: never;
+      }
   );
 
 /** Network trace filter configuration. */
@@ -462,7 +479,14 @@ export class GlubeanBrowser {
    */
   async wsEndpoint(): Promise<string> {
     const browser = await this._getBrowser();
-    return browser.wsEndpoint();
+    const endpoint = browser.wsEndpoint();
+    if (!endpoint) {
+      throw new Error(
+        "This Chrome session uses pipe transport and has no CDP WebSocket endpoint. " +
+          "glubean qa attach is unavailable; launch without extensions when an attachable session is required.",
+      );
+    }
+    return endpoint;
   }
 
   /** Close the browser and terminate the Chrome process. */
@@ -1032,7 +1056,7 @@ export class GlubeanPage {
         | "networkidle2";
     },
   ): Promise<void> {
-    const resolvedUrl = this._resolveUrl(url);
+    const resolvedUrl = resolveNavigationUrl(url, this._baseUrl);
     const start = Date.now();
 
     let response;
@@ -2357,14 +2381,20 @@ export class GlubeanPage {
     }
   }
 
-  private _resolveUrl(url: string): string {
-    if (!this._baseUrl) return url;
-    if (url.startsWith("http://") || url.startsWith("https://")) return url;
+}
 
-    const base = this._baseUrl.endsWith("/")
-      ? this._baseUrl.slice(0, -1)
-      : this._baseUrl;
-    const path = url.startsWith("/") ? url : `/${url}`;
-    return `${base}${path}`;
-  }
+/** @internal Resolve app-relative and supported absolute browser URLs. */
+export function resolveNavigationUrl(
+  url: string,
+  baseUrl: string | undefined,
+): string {
+  if (!baseUrl) return url;
+  // Browser tests commonly mix app-relative navigation with extension-origin
+  // pages. Preserve the prior HTTP(S) behavior plus Chrome extension URLs;
+  // do not broaden relative-path semantics for unrelated schemes.
+  if (/^(?:https?|chrome-extension):\/\//i.test(url)) return url;
+
+  const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  const path = url.startsWith("/") ? url : `/${url}`;
+  return `${base}${path}`;
 }

--- a/packages/browser/src/plugin-extension.test.ts
+++ b/packages/browser/src/plugin-extension.test.ts
@@ -1,0 +1,67 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { resolveTemplate, type GlubeanRuntime } from "@glubean/sdk";
+import { browser, resolveBrowserLaunchOptions } from "./plugin.js";
+
+const fixture = fileURLToPath(new URL("./chrome-extension/fixtures/extension", import.meta.url));
+
+function makeRuntime(vars: Record<string, string>): GlubeanRuntime {
+  return {
+    vars,
+    secrets: {},
+    http: {} as GlubeanRuntime["http"],
+    requireVar: (key) => {
+      const value = vars[key];
+      if (!value) throw new Error(`Missing required variable: ${key}`);
+      return value;
+    },
+    requireSecret: (key) => {
+      throw new Error(`Missing required secret: ${key}`);
+    },
+    resolveTemplate: (template) => resolveTemplate(template, vars, {}),
+    action: () => {},
+    trace: () => {},
+    event: () => {},
+    log: () => {},
+  };
+}
+
+describe("browser extension launch configuration", () => {
+  it("resolves extension path templates and composes Puppeteer launch options", () => {
+    const options = resolveBrowserLaunchOptions({
+      launch: true,
+      extensions: "{{EXTENSION_PATH}}",
+      launchOptions: { headless: "true", slowMo: "25" },
+    }, makeRuntime({ EXTENSION_PATH: fixture }));
+
+    expect(options).toMatchObject({
+      enableExtensions: [fixture],
+      pipe: true,
+      headless: true,
+      slowMo: 25,
+    });
+  });
+
+  it("supports a bare runtime variable key for an extension path", () => {
+    expect(resolveBrowserLaunchOptions({
+      launch: true,
+      extensions: "EXTENSION_PATH",
+    }, makeRuntime({ EXTENSION_PATH: fixture }))).toMatchObject({
+      enableExtensions: [fixture],
+      pipe: true,
+    });
+  });
+
+  it("rejects local extension paths in endpoint mode at runtime", async () => {
+    const client = browser({
+      endpoint: "CHROME_ENDPOINT",
+      extensions: fixture,
+    } as never).create(makeRuntime({
+      CHROME_ENDPOINT: "ws://127.0.0.1:9222/devtools/browser/test",
+    }));
+
+    await expect(client.wsEndpoint()).rejects.toThrow(
+      "cannot load local extensions in endpoint mode",
+    );
+  });
+});

--- a/packages/browser/src/plugin.ts
+++ b/packages/browser/src/plugin.ts
@@ -18,6 +18,10 @@ import type { GlubeanRuntime } from "@glubean/sdk";
 import type { Browser } from "puppeteer-core";
 import { type BrowserOptions, GlubeanBrowser } from "./page.js";
 import { connectChrome, launchChrome } from "./chrome.js";
+import {
+  extensionLaunchOptions,
+  type ExtensionLaunchOverrides,
+} from "./chrome-extension/launch.js";
 
 /**
  * Create a Glubean browser plugin.
@@ -93,6 +97,36 @@ function resolveLaunchOptions(
   return resolved;
 }
 
+function resolveExtensionPaths(
+  configured: string | readonly string[] | undefined,
+  runtime: GlubeanRuntime,
+): string | readonly string[] | undefined {
+  if (configured === undefined) return undefined;
+  const resolvePath = (extensionPath: string): string => {
+    if (extensionPath.includes("{{")) return runtime.resolveTemplate(extensionPath);
+    if (Object.prototype.hasOwnProperty.call(runtime.vars, extensionPath)) {
+      return runtime.requireVar(extensionPath);
+    }
+    return extensionPath;
+  };
+  if (typeof configured === "string") return resolvePath(configured);
+  return configured.map(resolvePath);
+}
+
+/** @internal Exported for focused launch-configuration tests. */
+export function resolveBrowserLaunchOptions(
+  options: Extract<BrowserOptions, { launch: true }>,
+  runtime: GlubeanRuntime,
+): Record<string, unknown> | undefined {
+  const resolvedLaunchOptions = resolveLaunchOptions(options.launchOptions, runtime);
+  const extensionPaths = resolveExtensionPaths(options.extensions, runtime);
+  if (extensionPaths === undefined) return resolvedLaunchOptions;
+  return extensionLaunchOptions(
+    extensionPaths,
+    resolvedLaunchOptions as ExtensionLaunchOverrides | undefined,
+  ) as unknown as Record<string, unknown>;
+}
+
 /**
  * Resolve the base URL while preserving the original bare-var-key contract.
  *
@@ -126,9 +160,14 @@ export function browser(options: BrowserOptions): { __type: GlubeanBrowser; crea
     function getBrowser(): Promise<Browser> {
       if (!browserPromise) {
         if ("launch" in options && options.launch) {
-          const resolvedLaunchOptions = resolveLaunchOptions(options.launchOptions, runtime);
+          const resolvedLaunchOptions = resolveBrowserLaunchOptions(options, runtime);
           browserPromise = launchChrome(options.executablePath, pptr, resolvedLaunchOptions);
         } else if ("endpoint" in options && options.endpoint) {
+          if ((options as { extensions?: unknown }).extensions !== undefined) {
+            throw new Error(
+              "browser() cannot load local extensions in endpoint mode; use { launch: true, extensions }.",
+            );
+          }
           const endpoint = runtime.requireVar(options.endpoint);
           browserPromise = connectChrome(endpoint, pptr);
         } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       puppeteer-core:
-        specifier: ^24.0.0
-        version: 24.39.0
+        specifier: ^24.41.0
+        version: 24.43.1
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -846,8 +846,8 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
-  '@puppeteer/browsers@2.13.0':
-    resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1315,8 +1315,8 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  devtools-protocol@0.0.1581282:
-    resolution: {integrity: sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==}
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -1792,8 +1792,8 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  puppeteer-core@24.39.0:
-    resolution: {integrity: sha512-SzIxz76Kgu17HUIi57HOejPiN0JKa9VCd2GcPY1sAh6RA4BzGZarFQdOYIYrBdUVbtyH7CrDb9uhGEwVXK/YNA==}
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
     engines: {node: '>=18'}
 
   qs@6.15.3:
@@ -2010,8 +2010,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typed-query-selector@2.12.1:
-    resolution: {integrity: sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==}
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2606,7 +2606,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@puppeteer/browsers@2.13.0':
+  '@puppeteer/browsers@2.13.2':
     dependencies:
       debug: 4.4.3
       extract-zip: 2.0.1
@@ -2969,9 +2969,9 @@ snapshots:
 
   check-error@2.1.3: {}
 
-  chromium-bidi@14.0.0(devtools-protocol@0.0.1581282):
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
     dependencies:
-      devtools-protocol: 0.0.1581282
+      devtools-protocol: 0.0.1608973
       mitt: 3.0.1
       zod: 3.25.76
 
@@ -3045,7 +3045,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  devtools-protocol@0.0.1581282: {}
+  devtools-protocol@0.0.1608973: {}
 
   dotenv@16.6.1: {}
 
@@ -3554,13 +3554,13 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  puppeteer-core@24.39.0:
+  puppeteer-core@24.43.1:
     dependencies:
-      '@puppeteer/browsers': 2.13.0
-      chromium-bidi: 14.0.0(devtools-protocol@0.0.1581282)
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
       debug: 4.4.3
-      devtools-protocol: 0.0.1581282
-      typed-query-selector: 2.12.1
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.1
       ws: 8.21.0
     transitivePeerDependencies:
@@ -3865,7 +3865,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typed-query-selector@2.12.1: {}
+  typed-query-selector@2.12.2: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary

- add `browser({ launch: true, extensions })` with validated, awaited unpacked extension installation
- ship Chrome-specific discovery, toolbar action, content-script, and native Side Panel helpers from `@glubean/browser/chrome-extension`
- migrate separate Options, Side Panel, and Content Script guides into the browser package
- cover extension URL, lifecycle, transport, symlink, and Puppeteer installation boundaries

## Verification

- `pnpm --filter @glubean/browser build`
- `pnpm --filter @glubean/browser test` (259 passed, 1 gated smoke skipped)
- `pnpm --filter @glubean/browser test:chrome-extension:smoke`
- `CI=1 pnpm -r build`
- `CI=1 pnpm -r test`
- Claude Code Opus 5 xhigh cross-host review converged in Round 5 with P0/P1/P2 at zero

Fixes #19