### PR TITLE
Add typed extension Side Panel capabilities

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -61,6 +61,7 @@ Chrome-specific helpers are exported from `@glubean/browser/chrome-extension`:
 - content-script ready-message watchers;
 - toolbar-action triggering through Puppeteer's `Extension` API;
 - native side-panel open/close verification;
+- typed `page.extension.sidePanel` capabilities for tests and browser contracts;
 - a `createExtensionTest()` convenience fixture.
 
 See Puppeteer's [Chrome extension guide](https://pptr.dev/guides/chrome-extensions)

--- a/packages/browser/guides/chrome-extension/README.md
+++ b/packages/browser/guides/chrome-extension/README.md
@@ -22,7 +22,7 @@ export const extension = resolveUnpackedExtension(
   path.resolve(process.env.CHROME_EXTENSION_PATH ?? "apps/extension/dist"),
 );
 
-export const { test } = createExtensionTest({
+export const { test, chrome } = createExtensionTest({
   extensions: extension.path,
   baseUrl: "APP_URL",
   launchOptions: {
@@ -47,6 +47,11 @@ cannot be reused by `glubean qa attach`. Use a separate launch without
 `chrome-extension://` URLs even when `baseUrl` is configured.
 The `extensions` option also accepts literal paths, `"{{EXTENSION_PATH}}"`
 templates, or a bare runtime variable key such as `"EXTENSION_PATH"`.
+
+Pages created by `createExtensionTest()` expose extension-only operations under
+`ctx.page.extension`. The same typed capability is inferred in
+`contract.browser` step actions when the scoped client comes from
+`browser({ launch: true, extensions })`.
 
 Run a guide as a normal Glubean test:
 

--- a/packages/browser/guides/chrome-extension/sidepanel.md
+++ b/packages/browser/guides/chrome-extension/sidepanel.md
@@ -13,17 +13,7 @@ the call follows a user action.
 See Chrome's [Side Panel API reference](https://developer.chrome.com/docs/extensions/reference/api/sidePanel).
 
 ```ts
-import {
-  closeExtensionSidePanel,
-  resolveExtensionPagePath,
-  triggerExtensionAction,
-  waitForExtensionOwnedPage,
-  waitForExtensionPageClosed,
-  waitForExtensionWorker,
-} from "@glubean/browser/chrome-extension";
 import { extension, test } from "./setup.js";
-
-const sidePanelPath = resolveExtensionPagePath(extension, "sidepanel");
 
 export const nativeSidePanel = test(
   {
@@ -34,37 +24,101 @@ export const nativeSidePanel = test(
   async (ctx) => {
     await ctx.page.goto("/sidepanel-fixture");
 
-    const loaded = await triggerExtensionAction(ctx.page.raw, {
-      path: extension.path,
+    const panel = await ctx.page.extension.sidePanel.open({
+      extension: { path: extension.path },
     });
-    const panel = await waitForExtensionOwnedPage(loaded, sidePanelPath);
-    await panel.waitForSelector("[data-testid=sidepanel-root]");
+    await panel.page.waitForSelector("[data-testid=sidepanel-root]");
 
-    ctx.expect(await panel.title()).toBe(
+    ctx.expect(await panel.page.title()).toBe(
       "Extension Side Panel",
       "the toolbar action opens the declared side-panel document",
     );
 
-    const worker = await waitForExtensionWorker(
-      ctx.page.raw.browser(),
-      loaded.id,
-    );
-    await closeExtensionSidePanel(worker.worker);
-    await waitForExtensionPageClosed(loaded, panel);
+    await panel.close();
   },
 );
+```
+
+`open()` defaults to the selected extension's manifest-declared
+`side_panel.default_path`. Use `pagePath` to override it. When one extension is
+loaded, omit `extension`; when several are loaded, select one by id, name, or
+unpacked-directory path. Calling `open()` while the matching panel is already
+active throws a targeted error; use `current()` to recover that handle instead.
+The optional `timeout` is one total budget for extension discovery and panel
+opening, rather than a separate budget for each stage.
+
+The returned `panel.page` is the raw Puppeteer page for the extension-owned
+document. It is intentionally outside the host page's single-page evidence
+window; use imperative assertions inside the step action. Declarative
+multi-page `contract.browser expect[]` support is a separate concern.
+
+The same capability is inferred for extension-backed browser contracts:
+
+```ts
+import { contract } from "@glubean/sdk";
+import { defineBrowserCase } from "@glubean/browser";
+import { chrome } from "./setup.js";
+
+const extensionUI = contract.browser.with("extensionUI", { client: chrome });
+
+export const nativeSidePanelLifecycle = extensionUI("native-side-panel-lifecycle", {
+  cases: {
+    openCloseReopen: defineBrowserCase({
+      description: "The toolbar action opens, closes, and reopens the native side panel.",
+      steps: [{
+        id: "open-close-reopen",
+        intent: "open the side panel, close it, and open it again",
+        action: async (page) => {
+          const first = await page.extension.sidePanel.open();
+          await first.close();
+          const second = await page.extension.sidePanel.open();
+          await second.close();
+        },
+      }],
+      expect: [],
+    }),
+  },
+});
 ```
 
 The extension must declare the `sidePanel` permission and configure its action
 to open the panel, for example with
 `chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })`.
 
-`triggerExtensionAction()` requires `puppeteer-core >= 24.41.0`.
-`closeExtensionSidePanel()` evaluates `chrome.sidePanel.close({ windowId })` in
-the extension worker and therefore requires Chrome 141 or newer. Pass an
-explicit `{ windowId }` when the test owns multiple Chrome windows.
+`sidePanel.open()` relies on Puppeteer's `Extension.triggerAction()` and
+therefore requires `puppeteer-core >= 24.41.0`. The handle's `close()` method
+evaluates `chrome.sidePanel.close({ windowId })` in the extension worker and
+therefore requires Chrome 141 or newer. Pass an explicit `{ windowId }` when
+the test owns multiple Chrome windows.
 
 To isolate panel rendering from browser action behavior, navigate directly to
-`extensionPageUrl(loaded.id, sidePanelPath)` in a separate test. That is useful
-component-level proof, but it does not prove the toolbar action or native panel
-container.
+the declared document in a separate test:
+
+```ts
+import {
+  extensionPageUrl,
+  getInstalledExtension,
+  resolveExtensionPagePath,
+} from "@glubean/browser/chrome-extension";
+import { extension, test } from "./setup.js";
+
+export const sidePanelDocument = test(
+  {
+    id: "side-panel-document",
+    name: "The declared Side Panel document renders in isolation",
+    tags: ["browser", "extension", "sidepanel"],
+  },
+  async (ctx) => {
+    const loaded = await getInstalledExtension(ctx.page.raw.browser());
+    const sidePanelPath = resolveExtensionPagePath(extension, "sidepanel");
+    await ctx.page.goto(extensionPageUrl(loaded.id, sidePanelPath));
+    ctx.expect(await ctx.page.title()).toBe(
+      "Extension Side Panel",
+      "the declared Side Panel document renders",
+    );
+  },
+);
+```
+
+That is useful component-level proof, but it does not prove the toolbar action
+or native panel container.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -25,7 +25,11 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run",
+    "pretest": "test -n \"$CI\" || pnpm --filter \"@glubean/browser...\" build",
+    "pretest:chrome-extension:smoke": "test -n \"$CI\" || pnpm --filter \"@glubean/browser...\" build",
+    "pretest:types": "test -n \"$CI\" || pnpm --filter \"@glubean/browser...\" build",
+    "test": "vitest run && tsc --noEmit -p tsconfig.test.json",
+    "test:types": "tsc --noEmit -p tsconfig.test.json",
     "test:chrome-extension:smoke": "vitest run src/chrome-extension/smoke.test.ts"
   },
   "publishConfig": {

--- a/packages/browser/src/chrome-extension/actions.test.ts
+++ b/packages/browser/src/chrome-extension/actions.test.ts
@@ -130,7 +130,10 @@ describe("installed extension actions", () => {
   });
 
   it("closes the native side panel through the extension worker", async () => {
-    const evaluate = vi.fn(async () => {});
+    const evaluate = vi.fn(async (
+      _fn: (...args: never[]) => unknown,
+      _windowId?: number,
+    ) => {});
     const worker = { evaluate } as unknown as WebWorker;
 
     await closeExtensionSidePanel(worker, { windowId: 7 });

--- a/packages/browser/src/chrome-extension/index.ts
+++ b/packages/browser/src/chrome-extension/index.ts
@@ -15,6 +15,17 @@ export type { ExtensionLaunchOverrides } from "./launch.js";
 export { createExtensionTest } from "./test.js";
 export type { ChromeExtensionTestOptions } from "./test.js";
 
+export { ExtensionBrowser } from "./page.js";
+export type {
+  CloseExtensionSidePanelOptions,
+  ExtensionController,
+  ExtensionPage,
+  ExtensionSidePanelController,
+  ExtensionSidePanelHandle,
+  ExtensionSidePanelTargetOptions,
+  OpenExtensionSidePanelOptions,
+} from "./page.js";
+
 export {
   extensionPageUrl,
   findExtensionTarget,

--- a/packages/browser/src/chrome-extension/launch.ts
+++ b/packages/browser/src/chrome-extension/launch.ts
@@ -1,5 +1,8 @@
 import type { LaunchOptions } from "puppeteer-core";
-import { resolveUnpackedExtensions } from "./manifest.js";
+import {
+  resolveUnpackedExtensions,
+  type UnpackedExtension,
+} from "./manifest.js";
 
 /** Launch options accepted by Puppeteer, excluding its extension switch. */
 export type ExtensionLaunchOverrides = Omit<LaunchOptions, "enableExtensions">;
@@ -15,6 +18,17 @@ export function extensionLaunchOptions(
   extensionPaths: string | readonly string[],
   overrides: ExtensionLaunchOverrides = {},
 ): LaunchOptions {
+  return extensionLaunchOptionsFromResolved(
+    resolveUnpackedExtensions(extensionPaths),
+    overrides,
+  );
+}
+
+/** @internal Compose launch options from already-validated extension metadata. */
+export function extensionLaunchOptionsFromResolved(
+  extensions: readonly UnpackedExtension[],
+  overrides: ExtensionLaunchOverrides = {},
+): LaunchOptions {
   if (overrides.pipe === false) {
     throw new Error(
       "Puppeteer requires pipe: true when loading unpacked Chrome extensions with enableExtensions.",
@@ -25,7 +39,6 @@ export function extensionLaunchOptions(
       "Do not set --remote-debugging-port or --remote-debugging-pipe in extension launch args; Puppeteer owns the required pipe transport.",
     );
   }
-  const extensions = resolveUnpackedExtensions(extensionPaths);
   return {
     ...overrides,
     headless: overrides.headless ?? false,

--- a/packages/browser/src/chrome-extension/page.test.ts
+++ b/packages/browser/src/chrome-extension/page.test.ts
@@ -1,0 +1,341 @@
+import { fileURLToPath } from "node:url";
+import type {
+  Browser,
+  Extension,
+  Page,
+  Target,
+  WebWorker,
+} from "puppeteer-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  GlubeanPage,
+  type BrowserTestContext,
+  type GlubeanBrowser,
+  type InstrumentedPage,
+} from "../page.js";
+import { resolveUnpackedExtension } from "./manifest.js";
+import { attachExtensionCapabilities } from "./page.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
+
+interface ExtensionHarness {
+  browser: Browser;
+  extension: Extension;
+  host: InstrumentedPage;
+  panel: Page;
+  triggerAction: ReturnType<typeof vi.fn>;
+  workerEvaluate: ReturnType<typeof vi.fn>;
+}
+
+function createHarness(options: { markPageClosedOnClose?: boolean } = {}): ExtensionHarness {
+  let panelOpen = false;
+  let panelClosed = false;
+  const panelTarget = {} as Target;
+  const panel = {
+    isClosed: () => panelClosed,
+    target: () => panelTarget,
+    title: async () => "Fixture Side Panel",
+    url: () => "chrome-extension://abc123/sidepanel.html?tab=7#/home",
+  } as unknown as Page;
+
+  const triggerAction = vi.fn(async () => {
+    panelOpen = true;
+    panelClosed = false;
+  });
+  const workerEvaluate = vi.fn(async (
+    _fn: (...args: never[]) => unknown,
+    _windowId?: number,
+  ) => {
+    panelOpen = false;
+    panelClosed = options.markPageClosedOnClose ?? true;
+  });
+  const worker = { evaluate: workerEvaluate } as unknown as WebWorker;
+  const workerTarget = {
+    type: () => "service_worker",
+    url: () => "chrome-extension://abc123/background.js",
+    worker: async () => worker,
+  } as unknown as Target;
+
+  const extension = {
+    id: "abc123",
+    name: "Fixture Extension",
+    version: "1.0.0",
+    path: fixture,
+    enabled: true,
+    pages: async () => panelOpen ? [panel] : [],
+    workers: async () => [worker],
+    triggerAction,
+  } as unknown as Extension;
+  const browser = {
+    extensions: async () => new Map([[extension.id, extension]]),
+    targets: () => [workerTarget],
+  } as unknown as Browser;
+  const hostRaw = { browser: () => browser } as unknown as Page;
+  const host = { raw: hostRaw } as InstrumentedPage;
+
+  return {
+    browser,
+    extension,
+    host,
+    panel,
+    triggerAction,
+    workerEvaluate,
+  };
+}
+
+describe("extension-scoped page capabilities", () => {
+  it("opens, finds, closes, and reopens the manifest-declared side panel", async () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+
+    await expect(page.extension.sidePanel.current()).resolves.toBeNull();
+
+    const first = await page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    });
+    expect(first.page).toBe(harness.panel);
+    expect(first.extensionId).toBe("abc123");
+    expect(first.path).toBe("sidepanel.html");
+    expect(harness.triggerAction).toHaveBeenCalledWith(page.raw);
+
+    const current = await page.extension.sidePanel.current();
+    expect(current?.page).toBe(harness.panel);
+
+    await first.close({ windowId: 7, timeout: 500, interval: 1 });
+    expect(harness.workerEvaluate).toHaveBeenCalledOnce();
+    expect(harness.workerEvaluate.mock.calls[0]?.[1]).toBe(7);
+    await expect(page.extension.sidePanel.current()).resolves.toBeNull();
+
+    const reopened = await page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    });
+    expect(reopened.page).toBe(harness.panel);
+    expect(harness.triggerAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the extension capability off the generic enumerable page surface", () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+
+    expect(page).toHaveProperty("extension.sidePanel.open");
+    expect(Object.keys(page)).not.toContain("extension");
+  });
+
+  it("attaches to a real InstrumentedPage Proxy without exposing an enumerable field", async () => {
+    const harness = createHarness();
+    const cdp = {
+      send: async () => ({}),
+      on() { return this; },
+      off() { return this; },
+      detach: async () => {},
+    };
+    const raw = {
+      browser: () => harness.browser,
+      createCDPSession: async () => cdp,
+      on() { return this; },
+      url: () => "https://example.test/",
+    } as unknown as Page;
+    const ctx: BrowserTestContext = {
+      action: () => {},
+      event: () => {},
+      trace: () => {},
+      metric: () => {},
+      log: () => {},
+      warn: () => {},
+    };
+    const proxy = await GlubeanPage._create(raw, undefined, ctx, {
+      launch: true,
+      consoleForward: false,
+      networkTrace: false,
+      passive: true,
+      screenshot: "off",
+    });
+    const page = attachExtensionCapabilities(proxy, [
+      resolveUnpackedExtension(fixture),
+    ]);
+
+    expect(page.extension.sidePanel.open).toBeTypeOf("function");
+    expect(Object.keys(page)).not.toContain("extension");
+    expect(() => attachExtensionCapabilities(page, [])).toThrow(
+      "capabilities are already attached",
+    );
+  });
+
+  it("registers returned panel pages with the owning browser lifecycle", async () => {
+    const harness = createHarness();
+    const track = vi.fn();
+    const owner = { _track: track } as unknown as GlubeanBrowser;
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ], owner);
+
+    const panel = await page.extension.sidePanel.open({ timeout: 500, interval: 1 });
+
+    expect(track).toHaveBeenCalledWith(panel.page);
+  });
+
+  it("forwards extension selection and supports an explicit side-panel path", async () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, []);
+
+    const handle = await page.extension.sidePanel.open({
+      extension: harness.extension.id,
+      pagePath: "/sidepanel.html?tab=7#/home",
+      timeout: 500,
+      interval: 1,
+    });
+
+    expect(handle.path).toBe("sidepanel.html");
+  });
+
+  it("rejects ambiguous active side-panel pages", async () => {
+    const harness = createHarness();
+    const second = {
+      isClosed: () => false,
+      url: () => "chrome-extension://abc123/sidepanel.html?window=2",
+    } as unknown as Page;
+    harness.extension.pages = async () => [harness.panel, second];
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+
+    await expect(page.extension.sidePanel.current()).rejects.toThrow(
+      "Multiple active side-panel pages matched",
+    );
+    await expect(page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    })).rejects.toThrow("Multiple active side-panel pages matched");
+  });
+
+  it("rejects open when the matching panel is already active", async () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+    await page.extension.sidePanel.open({ timeout: 500, interval: 1 });
+
+    await expect(page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    })).rejects.toThrow("side panel is already open");
+    expect(harness.triggerAction).toHaveBeenCalledOnce();
+  });
+
+  it("forwards extension discovery timing controls from current()", async () => {
+    const browser = {
+      extensions: async () => new Map(),
+    } as unknown as Browser;
+    const host = {
+      raw: { browser: () => browser } as unknown as Page,
+    } as InstrumentedPage;
+    const page = attachExtensionCapabilities(host, []);
+
+    await expect(page.extension.sidePanel.current({
+      timeout: 0,
+      interval: 1,
+    })).rejects.toThrow("within 0ms");
+  });
+
+  it("rejects empty explicit paths and missing manifest declarations", async () => {
+    const harness = createHarness();
+    const configured = resolveUnpackedExtension(fixture);
+    const page = attachExtensionCapabilities(harness.host, [configured]);
+
+    await expect(page.extension.sidePanel.current({
+      pagePath: "?tab=7",
+    })).rejects.toThrow("page path must not be empty");
+
+    const pageWithoutDeclaration = attachExtensionCapabilities(
+      { raw: harness.host.raw } as InstrumentedPage,
+      [{
+        ...configured,
+        manifest: { ...configured.manifest, side_panel: undefined },
+      }],
+    );
+    await expect(
+      pageWithoutDeclaration.extension.sidePanel.current(),
+    ).rejects.toThrow("does not declare side_panel.default_path");
+  });
+
+  it("treats closing an already-closed handle as an idempotent no-op", async () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+    const handle = await page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    });
+
+    await handle.close({ timeout: 500, interval: 1 });
+    await expect(handle.close()).resolves.toBeUndefined();
+    expect(harness.workerEvaluate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps handle close idempotent before Puppeteer flips page.isClosed()", async () => {
+    const harness = createHarness({ markPageClosedOnClose: false });
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+    const handle = await page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    });
+
+    await handle.close({ timeout: 500, interval: 1 });
+    expect(handle.page.isClosed()).toBe(false);
+    await handle.close();
+    expect(harness.workerEvaluate).toHaveBeenCalledOnce();
+  });
+
+  it("shares one close operation across concurrent callers", async () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+    const handle = await page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    });
+
+    await Promise.all([
+      handle.close({ timeout: 500, interval: 1 }),
+      handle.close({ timeout: 500, interval: 1 }),
+    ]);
+    expect(harness.workerEvaluate).toHaveBeenCalledOnce();
+  });
+
+  it("fails quickly with a targeted error when the worker is not observable", async () => {
+    const harness = createHarness();
+    const page = attachExtensionCapabilities(harness.host, [
+      resolveUnpackedExtension(fixture),
+    ]);
+    const handle = await page.extension.sidePanel.open({
+      timeout: 500,
+      interval: 1,
+    });
+    const waitForTarget = vi.fn(async (
+      _predicate: (target: Target) => boolean,
+      _options: { timeout?: number },
+    ) => {
+      throw new Error("Puppeteer target timeout");
+    });
+    Object.assign(harness.browser, {
+      targets: () => [],
+      waitForTarget,
+    });
+
+    await expect(handle.close({ timeout: 0 })).rejects.toThrow(
+      "Could not resolve the service worker",
+    );
+    expect(waitForTarget).toHaveBeenCalledOnce();
+    expect(waitForTarget.mock.calls[0]?.[1]).toEqual({ timeout: 1 });
+  });
+});

--- a/packages/browser/src/chrome-extension/page.ts
+++ b/packages/browser/src/chrome-extension/page.ts
@@ -1,0 +1,320 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Browser, Extension, Page } from "puppeteer-core";
+import type {
+  BrowserOptions,
+  BrowserTestContext,
+  InstrumentedPage,
+} from "../page.js";
+import { GlubeanBrowser } from "../page.js";
+import {
+  closeExtensionSidePanel,
+  getInstalledExtension,
+  waitForExtensionOwnedPage,
+  waitForExtensionPageClosed,
+  type InstalledExtensionSelector,
+  type InstalledExtensionWaitOptions,
+} from "./actions.js";
+import {
+  resolveExtensionPagePath,
+  type UnpackedExtension,
+} from "./manifest.js";
+import { parseExtensionUrl, waitForExtensionWorker } from "./targets.js";
+
+export interface ExtensionSidePanelTargetOptions
+  extends InstalledExtensionWaitOptions {
+  /** Select a loaded extension. Required when more than one extension is loaded. */
+  extension?: string | InstalledExtensionSelector;
+  /** Override the manifest-declared `side_panel.default_path`. */
+  pagePath?: string;
+  /**
+   * Total discovery/lifecycle timeout in milliseconds. Defaults to 10 seconds;
+   * 0 probes once without waiting.
+   */
+  timeout?: number;
+  /** Polling interval in milliseconds. Defaults to 50. */
+  interval?: number;
+}
+
+export type OpenExtensionSidePanelOptions = ExtensionSidePanelTargetOptions;
+
+export interface CloseExtensionSidePanelOptions
+  extends InstalledExtensionWaitOptions {
+  /** Chrome window containing the side panel. Required for multi-window tests. */
+  windowId?: number;
+  /**
+   * Total worker-discovery and close-wait timeout. Defaults to 10 seconds;
+   * 0 probes once without waiting.
+   */
+  timeout?: number;
+  /** Polling interval in milliseconds. Defaults to 50. */
+  interval?: number;
+}
+
+/** A native side panel together with the state needed to close that exact page. */
+export interface ExtensionSidePanelHandle {
+  /** Raw Puppeteer page for the extension-owned side-panel document. */
+  readonly page: Page;
+  readonly extensionId: string;
+  readonly path: string;
+  /**
+   * Close the native side panel and wait until this page is no longer active.
+   * Concurrent calls share the first in-flight close operation and its options.
+   */
+  close(options?: CloseExtensionSidePanelOptions): Promise<void>;
+}
+
+export interface ExtensionSidePanelController {
+  /** Trigger the real toolbar action and wait for the side-panel document. */
+  open(options?: OpenExtensionSidePanelOptions): Promise<ExtensionSidePanelHandle>;
+  /** Return the matching active side panel without triggering the toolbar action. */
+  current(
+    options?: ExtensionSidePanelTargetOptions,
+  ): Promise<ExtensionSidePanelHandle | null>;
+}
+
+export interface ExtensionController {
+  readonly sidePanel: ExtensionSidePanelController;
+}
+
+/**
+ * An instrumented host page created by a browser that loaded unpacked Chrome
+ * extensions. Extension-only behavior is scoped under `page.extension` rather
+ * than added to the generic `InstrumentedPage` surface.
+ */
+export type ExtensionPage = InstrumentedPage & {
+  readonly extension: ExtensionController;
+};
+
+/** Browser client whose pages carry extension-scoped capabilities. */
+export class ExtensionBrowser extends GlubeanBrowser {
+  private readonly _getExtensions: () => readonly UnpackedExtension[];
+
+  /** @internal Created by the `browser({ extensions })` client factory. */
+  constructor(
+    getBrowser: () => Promise<Browser>,
+    baseUrl: string | undefined,
+    options: BrowserOptions,
+    getExtensions: () => readonly UnpackedExtension[],
+  ) {
+    super(getBrowser, baseUrl, options);
+    this._getExtensions = getExtensions;
+  }
+
+  override async newPage(ctx: BrowserTestContext): Promise<ExtensionPage> {
+    const page = await super.newPage(ctx);
+    return attachExtensionCapabilities(page, this._getExtensions(), this);
+  }
+}
+
+/** @internal Attach extension capabilities to one SDK-created page instance. */
+export function attachExtensionCapabilities(
+  page: InstrumentedPage,
+  configuredExtensions: readonly UnpackedExtension[],
+  owner?: GlubeanBrowser,
+): ExtensionPage {
+  if (Object.prototype.hasOwnProperty.call(page, "extension")) {
+    throw new Error("Chrome extension capabilities are already attached to this page.");
+  }
+  const extension = createExtensionController(page, configuredExtensions, owner);
+  Object.defineProperty(page, "extension", {
+    configurable: false,
+    enumerable: false,
+    value: extension,
+    writable: false,
+  });
+  return page as ExtensionPage;
+}
+
+function createExtensionController(
+  hostPage: InstrumentedPage,
+  configuredExtensions: readonly UnpackedExtension[],
+  owner: GlubeanBrowser | undefined,
+): ExtensionController {
+  const createHandle = (
+    extension: Extension,
+    page: Page,
+    path: string,
+  ): ExtensionSidePanelHandle => {
+    owner?._track(page);
+    let closed = page.isClosed();
+    let closing: Promise<void> | undefined;
+    return {
+      page,
+      extensionId: extension.id,
+      path,
+      async close(options = {}): Promise<void> {
+        if (closed || page.isClosed()) {
+          closed = true;
+          return;
+        }
+        if (closing) return closing;
+
+        const budget = createTimeoutBudget(options.timeout);
+        closing = (async () => {
+          const workerTimeout = budget.remaining();
+          let worker: Awaited<ReturnType<typeof waitForExtensionWorker>>;
+          try {
+            worker = await waitForExtensionWorker(
+              hostPage.raw.browser(),
+              extension.id,
+              // Puppeteer treats timeout: 0 as "wait forever". Keep zero as
+              // an immediate probe by allowing at most a 1ms target wait.
+              { timeout: Math.max(1, workerTimeout) },
+            );
+          } catch (error) {
+            throw extensionWorkerTimeoutError(extension.id, workerTimeout, error);
+          }
+          await closeExtensionSidePanel(worker.worker, {
+            windowId: options.windowId,
+          });
+          await waitForExtensionPageClosed(extension, page, {
+            timeout: budget.remaining(),
+            interval: options.interval,
+          });
+          closed = true;
+        })();
+        try {
+          await closing;
+        } catch (error) {
+          closing = undefined;
+          throw error;
+        }
+      },
+    };
+  };
+
+  const resolvePath = (
+    extension: Extension,
+    requestedPath: string | undefined,
+  ): string => {
+    if (requestedPath !== undefined) return normalizePagePath(requestedPath);
+    const configured = configuredExtensions.find(
+      (candidate) => canonicalPath(candidate.path) === canonicalPath(extension.path),
+    );
+    if (!configured) {
+      throw new Error(
+        `Loaded Chrome extension ${extension.id} is not one of the configured unpacked extensions; ` +
+          `pass "pagePath" explicitly.`,
+      );
+    }
+    return normalizePagePath(resolveExtensionPagePath(configured, "sidepanel"));
+  };
+
+  const findCurrent = async (
+    extension: Extension,
+    path: string,
+  ): Promise<Page | null> => {
+    const matches = (await extension.pages()).filter((candidate) => {
+      if (candidate.isClosed()) return false;
+      try {
+        const parsed = parseExtensionUrl(candidate.url());
+        return parsed?.id === extension.id && parsed.path === path;
+      } catch {
+        return false;
+      }
+    });
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple active side-panel pages matched extension ${extension.id} and path ${path}; ` +
+          `use the low-level extension target helpers to select a specific window.`,
+      );
+    }
+    return matches[0] ?? null;
+  };
+
+  return {
+    sidePanel: {
+      async open(options = {}): Promise<ExtensionSidePanelHandle> {
+        const budget = createTimeoutBudget(options.timeout);
+        const extension = await getInstalledExtension(
+          hostPage.raw.browser(),
+          options.extension,
+          { timeout: budget.remaining(), interval: options.interval },
+        );
+        const path = resolvePath(extension, options.pagePath);
+        if (await findCurrent(extension, path)) {
+          throw new Error(
+            `Chrome side panel is already open for extension ${extension.id} and path ${path}; ` +
+              `use sidePanel.current() or close the existing handle before calling open().`,
+          );
+        }
+        if (typeof extension.triggerAction !== "function") {
+          throw new Error(
+            "This Puppeteer runtime does not expose Extension.triggerAction(); use puppeteer-core >= 24.41.0.",
+          );
+        }
+        await extension.triggerAction(hostPage.raw);
+        await waitForExtensionOwnedPage(extension, path, {
+          timeout: budget.remaining(),
+          interval: options.interval,
+        });
+        // Re-scan after the availability wait so a closed race is rejected and
+        // multiple same-path panels fail explicitly instead of picking one.
+        const page = await findCurrent(extension, path);
+        if (!page) {
+          throw new Error(
+            `Chrome side-panel page disappeared after opening: ${path}`,
+          );
+        }
+        return createHandle(extension, page, path);
+      },
+
+      async current(options = {}): Promise<ExtensionSidePanelHandle | null> {
+        const extension = await getInstalledExtension(
+          hostPage.raw.browser(),
+          options.extension,
+          { timeout: options.timeout, interval: options.interval },
+        );
+        const path = resolvePath(extension, options.pagePath);
+        const page = await findCurrent(extension, path);
+        return page ? createHandle(extension, page, path) : null;
+      },
+    },
+  };
+}
+
+function createTimeoutBudget(requestedTimeout: number | undefined): {
+  remaining(): number;
+} {
+  const timeout = Math.max(0, requestedTimeout ?? 10_000);
+  const deadline = Date.now() + timeout;
+  return {
+    remaining: () => Math.max(0, deadline - Date.now()),
+  };
+}
+
+function extensionWorkerTimeoutError(
+  extensionId: string,
+  timeout: number,
+  cause?: unknown,
+): Error {
+  return new Error(
+    `Could not resolve the service worker for Chrome extension ${extensionId} within ${timeout}ms; ` +
+      "ensure the extension background worker can activate before closing the Side Panel.",
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function normalizePagePath(path: string): string {
+  if (!path.trim()) {
+    throw new Error("Chrome extension side-panel page path must not be empty.");
+  }
+  const normalized = path.replace(/^\/+/, "").split(/[?#]/, 1)[0]!;
+  if (!normalized) {
+    throw new Error("Chrome extension side-panel page path must not be empty.");
+  }
+  try {
+    return decodeURIComponent(normalized);
+  } catch {
+    return normalized;
+  }
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}

--- a/packages/browser/src/chrome-extension/smoke.test.ts
+++ b/packages/browser/src/chrome-extension/smoke.test.ts
@@ -4,15 +4,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { resolveTemplate, type GlubeanRuntime } from "@glubean/sdk";
 import type { BrowserTestContext } from "../page.js";
 import { browser } from "../plugin.js";
-import {
-  closeExtensionSidePanel,
-  getInstalledExtension,
-  triggerExtensionAction,
-  waitForExtensionOwnedPage,
-  waitForExtensionPageClosed,
-} from "./actions.js";
+import { getInstalledExtension } from "./actions.js";
 import { installExtensionReadyWatcher } from "./ready.js";
-import { extensionPageUrl, waitForExtensionWorker } from "./targets.js";
+import { extensionPageUrl } from "./targets.js";
 
 const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
 const runSmoke =
@@ -95,14 +89,25 @@ describe.skipIf(!runSmoke)("real Chrome extension smoke", () => {
       )).toBe("true");
       await ready.dispose();
 
-      await triggerExtensionAction(page.raw, extension.id);
-      const sidePanel = await waitForExtensionOwnedPage(extension, "sidepanel.html");
-      await sidePanel.waitForSelector("[data-testid=sidepanel-root]");
-      expect(await sidePanel.title()).toBe("Fixture Side Panel");
+      await expect(page.extension.sidePanel.current({
+        extension: extension.id,
+      })).resolves.toBeNull();
 
-      const worker = await waitForExtensionWorker(page.raw.browser(), extension.id);
-      await closeExtensionSidePanel(worker.worker);
-      await waitForExtensionPageClosed(extension, sidePanel);
+      const sidePanel = await page.extension.sidePanel.open({
+        extension: extension.id,
+      });
+      await sidePanel.page.waitForSelector("[data-testid=sidepanel-root]");
+      expect(await sidePanel.page.title()).toBe("Fixture Side Panel");
+      await sidePanel.close();
+
+      await expect(page.extension.sidePanel.current({
+        extension: extension.id,
+      })).resolves.toBeNull();
+      const reopened = await page.extension.sidePanel.open({
+        extension: extension.id,
+      });
+      expect(await reopened.page.title()).toBe("Fixture Side Panel");
+      await reopened.close();
     } finally {
       await page.close();
       await chrome.close();

--- a/packages/browser/src/chrome-extension/test.test.ts
+++ b/packages/browser/src/chrome-extension/test.test.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { createExtensionTest } from "./test.js";
+import type { ExtensionBrowser, ExtensionPage } from "./page.js";
 
 const fixture = fileURLToPath(new URL("./fixtures/extension", import.meta.url));
 
@@ -10,5 +11,14 @@ describe("createExtensionTest", () => {
 
     expect(setup.test).toHaveProperty("extend");
     expect(setup.chrome).toBeDefined();
+    expectTypeOf(setup.chrome).toEqualTypeOf<ExtensionBrowser>();
+
+    setup.test({
+      id: "extension-page-type-fixture",
+      name: "The extension test fixture exposes extension-scoped page capabilities",
+      tags: ["browser", "extension", "types"],
+    }, async (ctx) => {
+      expectTypeOf(ctx.page).toEqualTypeOf<ExtensionPage>();
+    });
   });
 });

--- a/packages/browser/src/chrome-extension/test.ts
+++ b/packages/browser/src/chrome-extension/test.ts
@@ -1,6 +1,7 @@
 import { configure, test as baseTest, type ExtensionFn } from "@glubean/sdk";
-import type { BrowserOptions, BrowserTestContext, InstrumentedPage } from "../page.js";
+import type { BrowserOptions, BrowserTestContext } from "../page.js";
 import { browser } from "../plugin.js";
+import type { ExtensionPage } from "./page.js";
 
 export type ChromeExtensionTestOptions = Omit<
   Extract<BrowserOptions, { launch: true }>,
@@ -16,7 +17,7 @@ export function createExtensionTest(options: ChromeExtensionTestOptions) {
       chrome: browser({ ...options, launch: true }),
     },
   });
-  const pageFixture: ExtensionFn<InstrumentedPage> = async (ctx, use) => {
+  const pageFixture: ExtensionFn<ExtensionPage> = async (ctx, use) => {
     const page = await chrome.newPage(ctx as unknown as BrowserTestContext);
     try {
       await use(page);

--- a/packages/browser/src/contract/adapter.test.ts
+++ b/packages/browser/src/contract/adapter.test.ts
@@ -11,7 +11,7 @@
  * judges ALL expects and we can inspect every verdict.
  */
 
-import { beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, expectTypeOf, test } from "vitest";
 import { contract, installPlugin } from "@glubean/sdk";
 import type { ContractCaseRef, TestContext } from "@glubean/sdk";
 import browserPlugin, { browserAdapter, defineBrowserCase } from "../index.js";
@@ -23,6 +23,7 @@ import type {
   BrowserTraceRecord,
 } from "./types.js";
 import type { BrowserTestContext, GlubeanBrowser, InstrumentedPage } from "../page.js";
+import type { ExtensionPage } from "../chrome-extension/page.js";
 
 beforeAll(async () => {
   await installPlugin(browserPlugin);
@@ -975,5 +976,38 @@ describe("contract.browser factory", () => {
       resolvedInput: { email: "dogfood@example.com" },
     });
     expect(seenEmail).toBe("dogfood@example.com");
+  });
+
+  test("scoped clients propagate extension page capabilities into step actions", () => {
+    // This assertion is compile-time evidence enforced by the package's
+    // `test:types` gate; Vitest alone erases `expectTypeOf` at runtime.
+    const extensionBrowser = {
+      newPage: async (_ctx: BrowserTestContext) => ({} as ExtensionPage),
+    };
+    const extensionUI = (
+      contract as unknown as { browser: BrowserContractRoot }
+    ).browser.with("extensionUI", {
+      client: extensionBrowser,
+    });
+
+    extensionUI("native-side-panel", {
+      cases: {
+        openCloseReopen: defineBrowserCase({
+          description: "The native side panel opens, closes, and reopens from the toolbar action.",
+          steps: [
+            {
+              id: "open-close-reopen",
+              intent: "open the side panel, close it, and open it again",
+              action: async (page) => {
+                expectTypeOf(page).toEqualTypeOf<ExtensionPage>();
+                const panel = await page.extension.sidePanel.open();
+                await panel.close();
+              },
+            },
+          ],
+          expect: [],
+        }),
+      },
+    });
   });
 });

--- a/packages/browser/src/contract/adapter.ts
+++ b/packages/browser/src/contract/adapter.ts
@@ -38,8 +38,8 @@ import type {
 import { Expectation, genericMarkdownPart } from "@glubean/sdk";
 
 import type {
+  BrowserPageClient,
   BrowserTestContext,
-  GlubeanBrowser,
   InstrumentedPage,
 } from "../page.js";
 import {
@@ -121,7 +121,7 @@ function mergeNotes(base: string[] | undefined, more: string[] | undefined): str
 function resolveClient(
   caseSpec: BrowserContractCase,
   spec: BrowserContractSpec,
-): GlubeanBrowser {
+): BrowserPageClient {
   const client = caseSpec.client ?? spec.client;
   if (!client) {
     throw new Error(

--- a/packages/browser/src/contract/factory.ts
+++ b/packages/browser/src/contract/factory.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Extensions, ProtocolContract } from "@glubean/sdk";
+import type { InstrumentedPage } from "../page.js";
 import type {
   BrowserContractCase,
   BrowserContractDefaults,
@@ -26,15 +27,18 @@ import type {
   BrowserSafeSchemas,
 } from "./types.js";
 
-type InternalDefaults = BrowserContractDefaults & { _name?: string };
+type InternalDefaults<PageType extends InstrumentedPage> =
+  & BrowserContractDefaults<PageType>
+  & { _name?: string };
 
 type BrowserDispatch = <
-  Cases extends Record<string, BrowserContractCase<any>>,
+  PageType extends InstrumentedPage,
+  Cases extends Record<string, BrowserContractCase<any, PageType>>,
 >(
   id: string,
-  spec: BrowserContractSpec<Cases>,
+  spec: BrowserContractSpec<Cases, PageType>,
 ) => ProtocolContract<
-  BrowserContractSpec<Cases>,
+  BrowserContractSpec<Cases, PageType>,
   BrowserSafeSchemas,
   BrowserContractMeta,
   Cases
@@ -57,13 +61,16 @@ function mergeNotes(
   return all.length > 0 ? all : undefined;
 }
 
-function mergeBrowserDefaults(
-  defaults: InternalDefaults | undefined,
-  spec: BrowserContractSpec,
-): BrowserContractSpec {
+function mergeBrowserDefaults<
+  PageType extends InstrumentedPage,
+  Cases extends Record<string, BrowserContractCase<any, PageType>>,
+>(
+  defaults: InternalDefaults<PageType> | undefined,
+  spec: BrowserContractSpec<Cases, PageType>,
+): BrowserContractSpec<Cases, PageType> {
   if (!defaults) return spec;
   const mergedTags = [...(defaults.tags ?? []), ...(spec.tags ?? [])];
-  const baseMerged: BrowserContractSpec = {
+  const baseMerged: BrowserContractSpec<Cases, PageType> = {
     ...spec,
     client: spec.client ?? defaults.client,
     entry: spec.entry ?? defaults.entry,
@@ -87,17 +94,19 @@ function mergeBrowserDefaults(
  * Build a scoped browser factory. `dispatch` is `contract.browser` attached by
  * the core's register() call — we wrap it to inject instance defaults.
  */
-export function createBrowserFactory(
+export function createBrowserFactory<
+  PageType extends InstrumentedPage = InstrumentedPage,
+>(
   dispatch: BrowserDispatch,
-  defaults?: InternalDefaults,
-): BrowserContractFactory {
+  defaults?: InternalDefaults<PageType>,
+): BrowserContractFactory<PageType> {
   const factory = <
-    Cases extends Record<string, BrowserContractCase<any>>,
+    Cases extends Record<string, BrowserContractCase<any, PageType>>,
   >(
     id: string,
-    spec: BrowserContractSpec<Cases>,
+    spec: BrowserContractSpec<Cases, PageType>,
   ): ProtocolContract<
-    BrowserContractSpec<Cases>,
+    BrowserContractSpec<Cases, PageType>,
     BrowserSafeSchemas,
     BrowserContractMeta,
     Cases
@@ -109,14 +118,19 @@ export function createBrowserFactory(
           `then call instance("${id}", spec).`,
       );
     }
-    const merged = mergeBrowserDefaults(defaults, spec as unknown as BrowserContractSpec);
-    return dispatch(id, merged as unknown as BrowserContractSpec<Cases>);
+    const merged = mergeBrowserDefaults(defaults, spec);
+    return dispatch(id, merged);
   };
 
-  (factory as unknown as { with: BrowserContractRoot["with"] }).with = (
+  (factory as unknown as {
+    with: (
+      name: string,
+      more?: BrowserContractDefaults<PageType>,
+    ) => BrowserContractFactory<PageType>;
+  }).with = (
     name: string,
-    more: BrowserContractDefaults = {},
-  ): BrowserContractFactory => {
+    more: BrowserContractDefaults<PageType> = {},
+  ): BrowserContractFactory<PageType> => {
     const mergedTags = [...(defaults?.tags ?? []), ...(more.tags ?? [])];
     return createBrowserFactory(dispatch, {
       ...defaults,
@@ -128,7 +142,7 @@ export function createBrowserFactory(
     });
   };
 
-  return factory as BrowserContractFactory;
+  return factory as BrowserContractFactory<PageType>;
 }
 
 /**

--- a/packages/browser/src/contract/types.ts
+++ b/packages/browser/src/contract/types.ts
@@ -27,7 +27,7 @@
  *     `url` / `dom` (visible/absent) / `calls` (references a contract.http
  *     case — the killer feature) / `console`. Richer matchers are deferred.
  *
- * The Mode A executor is the resolved `GlubeanBrowser` client
+ * The Mode A executor is a resolved browser page client
  * (`configure({ plugins: { chrome: browser({...}) } })`), supplied via
  * `contract.browser.with({ client })` — same "client injection through a
  * scoped instance" pattern as HTTP / GraphQL / gRPC.
@@ -41,7 +41,10 @@ import type {
   SchemaLike,
   TestContext,
 } from "@glubean/sdk";
-import type { GlubeanBrowser, InstrumentedPage } from "../page.js";
+import type {
+  BrowserPageClient,
+  InstrumentedPage,
+} from "../page.js";
 
 // =============================================================================
 // Instance defaults (contract.browser.with)
@@ -52,14 +55,17 @@ import type { GlubeanBrowser, InstrumentedPage } from "../page.js";
  * (`contract.browser.with("name", {...})`).
  *
  * The `client` binding is the primary reason to use `.with`: supplying a
- * pre-configured `GlubeanBrowser` lets the adapter drive it without rebuilding
- * per contract. The client owns the real navigation base URL (it was fixed at
- * `browser({ baseUrl })` construction time); the contract-level `baseUrl` here
- * is **projection / display only** (mirrors GraphQL `endpoint`).
+ * pre-configured `GlubeanBrowser` or `ExtensionBrowser` lets the adapter drive
+ * it without rebuilding per contract. The client owns the real navigation
+ * base URL (it was fixed at `browser({ baseUrl })` construction time); the
+ * contract-level `baseUrl` here is **projection / display only** (mirrors
+ * GraphQL `endpoint`).
  */
-export interface BrowserContractDefaults {
+export interface BrowserContractDefaults<
+  PageType extends InstrumentedPage = InstrumentedPage,
+> {
   /** Default browser client for all contracts in this instance. */
-  client?: GlubeanBrowser;
+  client?: BrowserPageClient<PageType>;
   /**
    * Base URL **for projection / display only.** Travels on `meta.baseUrl` so
    * the scanner / `glubean contracts` markdown / MCP / Cloud can show which
@@ -181,7 +187,10 @@ export type BrowserExpect = { id: string } & (
  * execution directive AND the spec anchor an author/agent uses to repair
  * `action` when a replay drifts). `action` is the Mode A executable replay.
  */
-export interface BrowserStep<Input = void> {
+export interface BrowserStep<
+  Input = void,
+  PageType extends InstrumentedPage = InstrumentedPage,
+> {
   id: string;
   /** Structured instruction. Part of the canonical hash (journey semantics). */
   intent: string;
@@ -191,7 +200,7 @@ export interface BrowserStep<Input = void> {
    * `ctx.secrets`, etc.). NOT part of the hash. Absent → Mode A marks the
    * case unimplemented and skips (Mode B unaffected — `intent` is enough).
    */
-  action?: (page: InstrumentedPage, input: Input, ctx: TestContext) => Promise<void>;
+  action?: (page: PageType, input: Input, ctx: TestContext) => Promise<void>;
 }
 
 // =============================================================================
@@ -244,7 +253,10 @@ export type BrowserScreenshotStrategy = "final" | "each-step" | "on-failure";
  * `needs`), NOT setup state — v10 has no per-case lifecycle; setup-style work
  * belongs to a `contract.bootstrap()` overlay.
  */
-export interface BrowserContractCase<Input = void> extends BaseCaseSpec {
+export interface BrowserContractCase<
+  Input = void,
+  PageType extends InstrumentedPage = InstrumentedPage,
+> extends BaseCaseSpec {
   /** Per-case logical input schema (redeclares `BaseCaseSpec.needs`). */
   needs?: SchemaLike<Input>;
 
@@ -258,7 +270,7 @@ export interface BrowserContractCase<Input = void> extends BaseCaseSpec {
   agentNotes?: string[];
 
   /** Ordered journey steps. */
-  steps: BrowserStep<Input>[];
+  steps: BrowserStep<Input, PageType>[];
 
   /** Fixed-questionnaire expectations (stable ids). */
   expect?: BrowserExpect[];
@@ -267,7 +279,7 @@ export interface BrowserContractCase<Input = void> extends BaseCaseSpec {
   screenshot?: BrowserScreenshotStrategy;
 
   /** Per-case client override. */
-  client?: GlubeanBrowser;
+  client?: BrowserPageClient<PageType>;
 
   /**
    * Escape hatch: custom assertions over the frozen evidence bundle. Mode A
@@ -289,9 +301,12 @@ export interface BrowserContractCase<Input = void> extends BaseCaseSpec {
  * declared logical input instead of drifting from the `needs` schema (mirrors
  * `defineHttpCase` / `defineGraphqlCase`).
  */
-export function defineBrowserCase<Input = void>(
-  c: BrowserContractCase<Input>,
-): BrowserContractCase<Input> {
+export function defineBrowserCase<
+  Input = void,
+  PageType extends InstrumentedPage = InstrumentedPage,
+>(
+  c: BrowserContractCase<Input, PageType>,
+): BrowserContractCase<Input, PageType> {
   return c;
 }
 
@@ -309,13 +324,14 @@ export interface BrowserContractSpec<
   // rather than a single shared `Input` — otherwise a contract mixing cases with
   // different `needs` (or any input-bearing case) fails to type-check. Same shape
   // as GraphQL/gRPC (`GraphqlContractCase<Vars, Res, any>`).
-  Cases extends Record<string, BrowserContractCase<any>> = Record<
+  Cases extends Record<string, BrowserContractCase<any, any>> = Record<
     string,
     BrowserContractCase<any>
   >,
+  PageType extends InstrumentedPage = InstrumentedPage,
 > {
-  /** Browser client (resolved `GlubeanBrowser`) for all cases. */
-  client?: GlubeanBrowser;
+  /** Browser page client for all cases, preserving its instrumented page type. */
+  client?: BrowserPageClient<PageType>;
 
   /** Default entry path (relative to the client baseUrl) for cases. */
   entry?: string;
@@ -431,19 +447,21 @@ export type BrowserFlowCaseOutput = BrowserEvidence;
  * instance is the canonical pattern — same as HTTP / GraphQL / gRPC).
  */
 export type BrowserContractRoot = {
-  with: (
+  with: <PageType extends InstrumentedPage = InstrumentedPage>(
     instanceName: string,
-    defaults?: BrowserContractDefaults,
-  ) => BrowserContractFactory;
+    defaults?: BrowserContractDefaults<PageType>,
+  ) => BrowserContractFactory<PageType>;
 };
 
-export type BrowserContractFactory = <
-  Cases extends Record<string, BrowserContractCase<any>>,
+export type BrowserContractFactory<
+  PageType extends InstrumentedPage = InstrumentedPage,
+> = <
+  Cases extends Record<string, BrowserContractCase<any, PageType>>,
 >(
   id: string,
-  spec: BrowserContractSpec<Cases>,
+  spec: BrowserContractSpec<Cases, PageType>,
 ) => ProtocolContract<
-  BrowserContractSpec<Cases>,
+  BrowserContractSpec<Cases, PageType>,
   BrowserSafeSchemas,
   BrowserContractMeta,
   Cases

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -43,7 +43,18 @@ import { browserAdapter, createBrowserRoot } from "./contract/index.js";
 import type { BrowserContractRoot } from "./contract/index.js";
 
 export { browser } from "./plugin.js";
+export type { ExtensionBrowserOptions } from "./plugin.js";
 export { GlubeanBrowser, GlubeanPage } from "./page.js";
+export { ExtensionBrowser } from "./chrome-extension/page.js";
+export type {
+  CloseExtensionSidePanelOptions,
+  ExtensionController,
+  ExtensionPage,
+  ExtensionSidePanelController,
+  ExtensionSidePanelHandle,
+  ExtensionSidePanelTargetOptions,
+  OpenExtensionSidePanelOptions,
+} from "./chrome-extension/page.js";
 export { connectChrome, resolveEndpoint, launchChrome } from "./chrome.js";
 
 /**
@@ -76,12 +87,13 @@ export type {
   BrowserAction,
   BrowserEvent,
   BrowserOptions,
+  BrowserPageClient,
   BrowserTestContext,
   DialogHandler,
   DialogMode,
   InstrumentedPage,
-  PuppeteerLike,
   NetworkTraceOptions,
+  PuppeteerLike,
   ResponseChecks,
 } from "./page.js";
 export type {

--- a/packages/browser/src/page-extension.test.ts
+++ b/packages/browser/src/page-extension.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import type { Browser } from "puppeteer-core";
+import { describe, expect, it, vi } from "vitest";
+import type { Browser, Page } from "puppeteer-core";
 import { GlubeanBrowser, resolveNavigationUrl } from "./page.js";
 
 describe("extension-origin navigation", () => {
@@ -28,5 +28,33 @@ describe("extension-origin navigation", () => {
     await expect(chrome.wsEndpoint()).rejects.toThrow(
       "pipe transport and has no CDP WebSocket endpoint",
     );
+  });
+
+  it("counts the same raw page only once in browser lifecycle tracking", async () => {
+    vi.useFakeTimers();
+    try {
+      const close = vi.fn(async () => {});
+      const rawBrowser = { close } as unknown as Browser;
+      const chrome = new GlubeanBrowser(
+        async () => rawBrowser,
+        undefined,
+        { launch: true },
+      );
+      let onClose: (() => void) | undefined;
+      const once = vi.fn((_event: string, listener: () => void) => {
+        onClose = listener;
+      });
+      const rawPage = { once } as unknown as Page;
+
+      chrome._track(rawPage);
+      chrome._track(rawPage);
+      expect(once).toHaveBeenCalledOnce();
+
+      onClose?.();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/browser/src/page.ts
+++ b/packages/browser/src/page.ts
@@ -41,6 +41,20 @@ import { getRuntime } from "@glubean/sdk/internal";
  */
 export type InstrumentedPage = GlubeanPage & Page;
 
+/**
+ * Minimal browser-client shape consumed by `contract.browser`.
+ *
+ * The page type is generic so a browser launched with additional capabilities
+ * (for example a loaded Chrome extension) can expose those capabilities to
+ * contract step actions without adding invalid methods to every
+ * `InstrumentedPage`.
+ */
+export interface BrowserPageClient<
+  PageType extends InstrumentedPage = InstrumentedPage,
+> {
+  newPage(ctx: BrowserTestContext): Promise<PageType>;
+}
+
 /** Per-action options for interaction methods. */
 export interface ActionOptions {
   /** Timeout in ms (overrides the global `actionTimeout`). */
@@ -371,6 +385,7 @@ export class GlubeanBrowser {
   private readonly _baseUrl: string | undefined;
   private readonly _options: BrowserOptions;
   private _openPages = 0;
+  private readonly _trackedPages = new WeakSet<Page>();
   private _closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** @internal — created by the plugin factory. */
@@ -430,6 +445,8 @@ export class GlubeanBrowser {
    * real pages that must keep the browser open too).
    */
   _track(rawPage: Page): void {
+    if (this._trackedPages.has(rawPage)) return;
+    this._trackedPages.add(rawPage);
     if (this._closeTimer) {
       clearTimeout(this._closeTimer);
       this._closeTimer = null;

--- a/packages/browser/src/plugin-extension.test.ts
+++ b/packages/browser/src/plugin-extension.test.ts
@@ -1,7 +1,12 @@
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { resolveTemplate, type GlubeanRuntime } from "@glubean/sdk";
 import { browser, resolveBrowserLaunchOptions } from "./plugin.js";
+import {
+  ExtensionBrowser,
+  type ExtensionBrowserOptions,
+  type ExtensionPage,
+} from "./index.js";
 
 const fixture = fileURLToPath(new URL("./chrome-extension/fixtures/extension", import.meta.url));
 
@@ -27,6 +32,32 @@ function makeRuntime(vars: Record<string, string>): GlubeanRuntime {
 }
 
 describe("browser extension launch configuration", () => {
+  it("returns an extension-aware browser client when extensions are configured", () => {
+    const options: ExtensionBrowserOptions = {
+      launch: true,
+      extensions: fixture,
+    };
+    const client = browser(options).create(makeRuntime({}));
+
+    expect(client).toBeInstanceOf(ExtensionBrowser);
+    expectTypeOf(client).toEqualTypeOf<ExtensionBrowser>();
+    expectTypeOf<Awaited<ReturnType<ExtensionBrowser["newPage"]>>>()
+      .toEqualTypeOf<ExtensionPage>();
+  });
+
+  it("keeps unpacked-extension validation lazy until Chrome is requested", async () => {
+    const missing = "/definitely-not-a-real-glubean-extension";
+    const client = browser({
+      launch: true,
+      extensions: missing,
+    }).create(makeRuntime({}));
+
+    expect(client.isLaunched).toBe(true);
+    await expect(client.newPage({} as never)).rejects.toThrow(
+      `Chrome extension directory does not exist: ${missing}`,
+    );
+  });
+
   it("resolves extension path templates and composes Puppeteer launch options", () => {
     const options = resolveBrowserLaunchOptions({
       launch: true,

--- a/packages/browser/src/plugin.ts
+++ b/packages/browser/src/plugin.ts
@@ -2,8 +2,9 @@
  * Glubean browser plugin factory.
  *
  * Uses `defineClientFactory()` from the SDK to create a lazily-initialized
- * browser connection. Returns a `GlubeanBrowser` with a `newPage(ctx)` method
- * that creates fully instrumented pages wired to the test context.
+ * browser connection. Returns a `GlubeanBrowser`, or an `ExtensionBrowser`
+ * when unpacked extensions are configured, whose `newPage(ctx)` method creates
+ * fully instrumented pages wired to the test context.
  *
  * Supports three connection modes:
  * - `launch: true` — auto-detect and start local Chrome headless
@@ -14,14 +15,24 @@
  */
 
 import { defineClientFactory } from "@glubean/sdk";
-import type { GlubeanRuntime } from "@glubean/sdk";
+import type { ClientFactory, GlubeanRuntime } from "@glubean/sdk";
 import type { Browser } from "puppeteer-core";
 import { type BrowserOptions, GlubeanBrowser } from "./page.js";
 import { connectChrome, launchChrome } from "./chrome.js";
 import {
   extensionLaunchOptions,
+  extensionLaunchOptionsFromResolved,
   type ExtensionLaunchOverrides,
 } from "./chrome-extension/launch.js";
+import {
+  resolveUnpackedExtensions,
+  type UnpackedExtension,
+} from "./chrome-extension/manifest.js";
+import { ExtensionBrowser } from "./chrome-extension/page.js";
+
+export type ExtensionBrowserOptions = Extract<BrowserOptions, { launch: true }> & {
+  extensions: string | readonly string[];
+};
 
 /**
  * Create a Glubean browser plugin.
@@ -117,8 +128,15 @@ function resolveExtensionPaths(
 export function resolveBrowserLaunchOptions(
   options: Extract<BrowserOptions, { launch: true }>,
   runtime: GlubeanRuntime,
+  resolvedExtensions?: readonly UnpackedExtension[],
 ): Record<string, unknown> | undefined {
   const resolvedLaunchOptions = resolveLaunchOptions(options.launchOptions, runtime);
+  if (resolvedExtensions !== undefined) {
+    return extensionLaunchOptionsFromResolved(
+      resolvedExtensions,
+      resolvedLaunchOptions as ExtensionLaunchOverrides | undefined,
+    ) as unknown as Record<string, unknown>;
+  }
   const extensionPaths = resolveExtensionPaths(options.extensions, runtime);
   if (extensionPaths === undefined) return resolvedLaunchOptions;
   return extensionLaunchOptions(
@@ -149,19 +167,52 @@ function resolveBaseUrl(
   return runtime.requireVar(configured);
 }
 
-export function browser(options: BrowserOptions): { __type: GlubeanBrowser; create: (runtime: GlubeanRuntime) => GlubeanBrowser } {
+export function browser(options: ExtensionBrowserOptions): ClientFactory<ExtensionBrowser>;
+export function browser(options: BrowserOptions): ClientFactory<GlubeanBrowser>;
+export function browser(options: BrowserOptions): ClientFactory<GlubeanBrowser> {
   return defineClientFactory((runtime: GlubeanRuntime): GlubeanBrowser => {
     const baseUrl = resolveBaseUrl(options.baseUrl, runtime);
-
     let browserPromise: Promise<Browser> | null = null;
+    let launchConfiguration: {
+      extensions?: readonly UnpackedExtension[];
+      options?: Record<string, unknown>;
+    } | undefined;
 
     const pptr = options.puppeteer;
+
+    function getLaunchConfiguration(): NonNullable<typeof launchConfiguration> {
+      if (launchConfiguration) return launchConfiguration;
+      if (!("launch" in options) || !options.launch) {
+        launchConfiguration = {};
+        return launchConfiguration;
+      }
+      const extensionPaths = resolveExtensionPaths(options.extensions, runtime);
+      const extensions = extensionPaths === undefined
+        ? undefined
+        : resolveUnpackedExtensions(extensionPaths);
+      launchConfiguration = {
+        extensions,
+        options: resolveBrowserLaunchOptions(options, runtime, extensions),
+      };
+      return launchConfiguration;
+    }
+
+    function getConfiguredExtensions(): readonly UnpackedExtension[] {
+      const extensions = getLaunchConfiguration().extensions;
+      if (!extensions) {
+        throw new Error("ExtensionBrowser requires at least one configured unpacked extension.");
+      }
+      return extensions;
+    }
 
     function getBrowser(): Promise<Browser> {
       if (!browserPromise) {
         if ("launch" in options && options.launch) {
-          const resolvedLaunchOptions = resolveBrowserLaunchOptions(options, runtime);
-          browserPromise = launchChrome(options.executablePath, pptr, resolvedLaunchOptions);
+          browserPromise = launchChrome(
+            options.executablePath,
+            pptr,
+            getLaunchConfiguration().options,
+          );
         } else if ("endpoint" in options && options.endpoint) {
           if ((options as { extensions?: unknown }).extensions !== undefined) {
             throw new Error(
@@ -179,6 +230,10 @@ export function browser(options: BrowserOptions): { __type: GlubeanBrowser; crea
       return browserPromise;
     }
 
-    return new GlubeanBrowser(getBrowser, baseUrl, options);
+    const extensionMode = "launch" in options && options.launch &&
+      options.extensions !== undefined;
+    return extensionMode
+      ? new ExtensionBrowser(getBrowser, baseUrl, options, getConfiguredExtensions)
+      : new GlubeanBrowser(getBrowser, baseUrl, options);
   });
 }

--- a/packages/browser/tsconfig.test.json
+++ b/packages/browser/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/cli/src/commands/qa.test.ts
+++ b/packages/cli/src/commands/qa.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserPageClient } from "@glubean/browser";
+import { isQaManagedBrowserClient, qaOpenCommand } from "./qa.js";
+
+vi.mock("@glubean/runner", () => ({
+  bootstrap: vi.fn(async () => {}),
+}));
+
+const minimalClient: BrowserPageClient = {
+  newPage: async () => ({} as never),
+};
+
+describe("qa managed browser client detection", () => {
+  it("rejects a page-only contract client", () => {
+    expect(isQaManagedBrowserClient(minimalClient)).toBe(false);
+  });
+
+  it("accepts the managed lifecycle returned by browser({ launch: true })", () => {
+    const managed = {
+      ...minimalClient,
+      isLaunched: true,
+      wsEndpoint: async () => "ws://127.0.0.1/devtools/browser/test",
+      close: async () => {},
+    };
+
+    expect(isQaManagedBrowserClient(managed)).toBe(true);
+  });
+
+  it("wires the guard into qa open before managed lifecycle methods are used", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "glubean-qa-client-"));
+    const fixture = join(directory, "minimal.browser.mjs");
+    writeFileSync(fixture, `
+      export const journey = {
+        _spec: {
+          client: { newPage: async () => ({}) },
+          cases: { minimal: { description: "minimal", steps: [] } },
+        },
+        _extracted: {
+          id: "qa.minimal",
+          protocol: "browser",
+          cases: [{ key: "minimal", schemas: {} }],
+        },
+      };
+    `);
+    try {
+      await expect(qaOpenCommand({
+        file: fixture,
+        case: "minimal",
+        model: "test-model",
+      })).rejects.toThrow(
+        "contract client does not expose managed-browser lifecycle methods",
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/qa.ts
+++ b/packages/cli/src/commands/qa.ts
@@ -31,10 +31,15 @@ import {
   type AgentQaReport,
   type BrowserContractCase,
   type BrowserEvidence,
+  type BrowserPageClient,
   type BrowserTraceRecord,
-  type GlubeanBrowser,
-  type InstrumentedPage,
 } from "@glubean/browser";
+
+type QaManagedBrowserClient = BrowserPageClient & {
+  readonly isLaunched: boolean;
+  wsEndpoint(): Promise<string>;
+  close(): Promise<void>;
+};
 
 /**
  * Build a minimal runtime carrying env vars/secrets so importing a `.browser.ts`
@@ -127,12 +132,12 @@ async function loadBrowserCase(
   file: string,
   caseKey: string,
   contractId?: string,
-): Promise<{ contractId: string; caseSpec: BrowserContractCase; client?: GlubeanBrowser; revision: string }> {
+): Promise<{ contractId: string; caseSpec: BrowserContractCase; client?: BrowserPageClient; revision: string }> {
   const abs = resolve(file);
   await bootstrap(dirname(abs)); // installs the browser plugin via glubean.setup.ts
   const mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
   type PC = {
-    _spec?: { cases?: Record<string, unknown>; client?: GlubeanBrowser };
+    _spec?: { cases?: Record<string, unknown>; client?: BrowserPageClient };
     _extracted?: { id?: string; protocol?: string; cases?: Array<{ key: string; schemas?: unknown }> };
   };
   // Collect ALL browser contracts carrying the case key — do not silently pick
@@ -183,6 +188,18 @@ async function loadBrowserCase(
   // Mode A resolves the client case > spec.
   const client = caseSpec.client ?? pc._spec!.client;
   return { contractId: pc._extracted!.id ?? "unknown", caseSpec, client, revision };
+}
+
+/** @internal Return whether a contract client supports `qa open` lifecycle control. */
+export function isQaManagedBrowserClient(
+  client: BrowserPageClient,
+): client is QaManagedBrowserClient {
+  const candidate = client as Partial<QaManagedBrowserClient>;
+  return (
+    typeof candidate.isLaunched === "boolean" &&
+    typeof candidate.wsEndpoint === "function" &&
+    typeof candidate.close === "function"
+  );
 }
 
 /** Wait until the trace buffer stops growing (bounded) before sealing. */
@@ -273,6 +290,12 @@ export async function qaOpenCommand(opts: { file: string; case: string; report?:
   await runWithRuntime(buildRuntime(), async () => {
     const { contractId, caseSpec, client, revision } = await loadBrowserCase(opts.file, opts.case, opts.contract);
     if (!client) throw new Error("qa open: the contract has no browser client to launch.");
+    if (!isQaManagedBrowserClient(client)) {
+      throw new Error(
+        "qa open: the contract client does not expose managed-browser lifecycle methods; " +
+          "use the client returned by browser({ launch: true }).",
+      );
+    }
     if (!client.isLaunched) {
       throw new Error(
         "qa open: the contract's client is endpoint-backed (browser({ endpoint })), whose Chrome is owned by " +


### PR DESCRIPTION
## Summary

- add `ExtensionBrowser` / `ExtensionPage` with instance-scoped `page.extension.sidePanel` lifecycle capabilities
- infer `ExtensionPage` through `createExtensionTest()` and extension-backed `contract.browser` step actions
- keep panel pages in browser lifecycle accounting, make close idempotent, handle ambiguity and timeout edges, and preserve lazy extension validation
- document the imperative Side Panel workflow while keeping declarative multi-page `expect[]` out of scope

## Validation

- `CI=1 pnpm -r build`
- `CI=1 pnpm -r test`
- `pnpm --filter @glubean/browser test:chrome-extension:smoke` (real Chrome open, close, absent, reopen, close)
- Claude Code Opus xhigh foundation review: converged after four rounds with P0/P1/P2/P3 all zero

Fixes #24
