### PR TITLE
sdk: curried httpCase factory — infer Needs from the schema, keep typed flow res.body

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -140,7 +140,7 @@ Current automatic changes:
 | `contract.http("id", spec)` | Adds a scoped `contract.http.with(...)` instance and calls it |
 | `import "@glubean/grpc"` / `import "@glubean/graphql"` | Moves plugin installation into `glubean.setup.ts` |
 
-Manual review items are reported for removed case-level `setup` / `teardown`, legacy `definePlugin((runtime) => ...)`, and cases with `needs` that should be wrapped in `httpCase(schema)({ ... })`.
+Manual review items are reported for removed case-level `setup` / `teardown`, legacy `definePlugin((runtime) => ...)`, and cases with `needs` whose schema should move into `httpCase(<schema>)({ ... })` — the `needs` key is then removed from the case literal, which the factory rejects.
 
 ### `validate-metadata`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -140,7 +140,7 @@ Current automatic changes:
 | `contract.http("id", spec)` | Adds a scoped `contract.http.with(...)` instance and calls it |
 | `import "@glubean/grpc"` / `import "@glubean/graphql"` | Moves plugin installation into `glubean.setup.ts` |
 
-Manual review items are reported for removed case-level `setup` / `teardown`, legacy `definePlugin((runtime) => ...)`, and cases with `needs` that should be wrapped in `defineHttpCase<Needs>(...)`.
+Manual review items are reported for removed case-level `setup` / `teardown`, legacy `definePlugin((runtime) => ...)`, and cases with `needs` that should be wrapped in `httpCase(schema)({ ... })`.
 
 ### `validate-metadata`
 

--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -56,7 +56,7 @@ export const createUser = contract.http("create-user", {
     expect(stdout).toContain('Rewrite contract.http("id", spec)');
     expect(stdout).toContain("Move @glubean/graphql side-effect plugin import");
     expect(stdout).toContain("Case-level setup was removed");
-    expect(stdout).toContain("defineHttpCase<Needs>");
+    expect(stdout).toContain("httpCase(schema)({ ... })");
     expect(stdout).toContain("+++ glubean.setup.ts");
 
     await expect(readFile(contractPath, "utf-8")).resolves.toBe(original);

--- a/packages/cli/src/commands/migrate.test.ts
+++ b/packages/cli/src/commands/migrate.test.ts
@@ -56,7 +56,8 @@ export const createUser = contract.http("create-user", {
     expect(stdout).toContain('Rewrite contract.http("id", spec)');
     expect(stdout).toContain("Move @glubean/graphql side-effect plugin import");
     expect(stdout).toContain("Case-level setup was removed");
-    expect(stdout).toContain("httpCase(schema)({ ... })");
+    expect(stdout).toContain("move the schema into httpCase(<schema>)({ ... })");
+    expect(stdout).toContain("remove `needs` from the case literal");
     expect(stdout).toContain("+++ glubean.setup.ts");
 
     await expect(readFile(contractPath, "utf-8")).resolves.toBe(original);

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -350,7 +350,10 @@ function collectCaseFindings(
     for (const caseProp of property.initializer.properties) {
       if (!ts.isPropertyAssignment(caseProp)) continue;
       const value = caseProp.initializer;
-      if (ts.isCallExpression(value) && ts.isIdentifier(value.expression) && value.expression.text === "defineHttpCase") {
+      // Already routed through a case factory — `httpCase(schema)({ ... })`
+      // (curried, so the outer callee is itself a call) or the deprecated
+      // `defineHttpCase(...)`. Nothing to report either way.
+      if (ts.isCallExpression(value) && isCaseFactoryCallee(ts, value.expression)) {
         continue;
       }
       if (!ts.isObjectLiteralExpression(value)) continue;
@@ -371,12 +374,22 @@ function collectCaseFindings(
             file,
             line: lineOf(ts, sourceFile, field),
             code: "needs-factory",
-            message: "Case has needs; wrap the case in defineHttpCase<Needs>(...) to preserve body/input typing.",
+            message: "Case has needs; wrap the case in httpCase(schema)({ ... }) to preserve body/input typing.",
           });
         }
       }
     }
   }
+}
+
+/**
+ * Callee of a case-factory call. `httpCase(schema)({ ... })` is curried, so its
+ * callee is the `httpCase(schema)` call itself; the deprecated
+ * `defineHttpCase(...)` takes the case in one call.
+ */
+function isCaseFactoryCallee(ts: TS, callee: import("typescript").Expression): boolean {
+  if (ts.isIdentifier(callee)) return callee.text === "defineHttpCase";
+  return ts.isCallExpression(callee) && ts.isIdentifier(callee.expression) && callee.expression.text === "httpCase";
 }
 
 function isLegacyHttpCall(ts: TS, node: import("typescript").CallExpression): boolean {

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -374,7 +374,8 @@ function collectCaseFindings(
             file,
             line: lineOf(ts, sourceFile, field),
             code: "needs-factory",
-            message: "Case has needs; wrap the case in httpCase(schema)({ ... }) to preserve body/input typing.",
+            message:
+              "Case has needs; move the schema into httpCase(<schema>)({ ... }) and remove `needs` from the case literal to preserve body/input typing.",
           });
         }
       }

--- a/packages/sdk/src/attachment-model.test-d.ts
+++ b/packages/sdk/src/attachment-model.test-d.ts
@@ -291,7 +291,7 @@ import { defineHttpCase } from "./index.js";
 // =============================================================================
 
 import { httpCase } from "./index.js";
-import type { ContractCase } from "./index.js";
+import type { ContractCase, HttpCaseBody } from "./index.js";
 import type { ExtractCaseResponse } from "./contract-types.js";
 
 {
@@ -407,6 +407,18 @@ import type { ExtractCaseResponse } from "./contract-types.js";
   });
   void _zeroArgDoubleDeclared;
 
+  // ...but an explicit `needs: undefined` DECLARES NOTHING and compiles:
+  // `exactOptionalPropertyTypes` is off, so `needs?: never` admits undefined.
+  // The runtime tolerates it for exactly this reason (see http-case.test.ts) —
+  // the two layers must promise the same thing.
+  const _explicitUndefined = httpCase(s<{ email: string }>())({
+    description: "explicit undefined declares nothing",
+    needs: undefined,
+    body: ({ email }) => ({ email }),
+    expect: { status: 200 },
+  });
+  void _explicitUndefined;
+
   // ---------------------------------------------------------------------
   // 5.6 The returned case is accepted by the real contract factory, and the
   // resulting `.case()` ref carries the schema-typed body.
@@ -430,4 +442,72 @@ import type { ExtractCaseResponse } from "./contract-types.js";
   type OkOutput = typeof okRef extends { __phantom_output?: infer O } ? O : never;
   const _okBodyName: string = ({} as OkOutput).body.name;
   void _okBodyName;
+}
+
+// =============================================================================
+// Test 5.7 (regression): a case body written against the EXPORTED
+// `HttpCaseBody<N>` annotation must survive the factory.
+//
+// `HttpCaseBody` carries the `needs?: never` single-declaration guard, so a
+// bare `C & { needs: SchemaLike<N> }` return type intersects `never` with a
+// required property and collapses `needs` — taking `InferCaseInput` (and with
+// it the whole `.case()` I/O chain) down to `never`. The return type drops the
+// guarded key first (`Omit<C, "needs"> & ...`), which is what these assert.
+// =============================================================================
+
+{
+  type Needs = { email: string };
+
+  const preAnnotated: HttpCaseBody<Needs> = {
+    description: "pre-annotated case body",
+    body: ({ email }) => ({ email }),
+    expect: { status: 200, schema: s<{ name: string }>() },
+  };
+
+  const built = httpCase(s<Needs>())(preAnnotated);
+
+  // `needs` must be the schema, NOT `never`.
+  const _needsUsable: SchemaLike<Needs> = built.needs;
+  const _needsNotNever: [(typeof built)["needs"]] extends [never] ? true : false = false;
+  // Other fields stay reachable (a collapsed intersection makes the whole
+  // object unusable, not just its `needs`).
+  const _descReachable: string = built.description;
+  void _needsUsable;
+  void _needsNotNever;
+  void _descReachable;
+
+  // InferCaseInput must be EXACTLY Needs — asserted both ways, since a
+  // one-way `extends` also holds for `never`.
+  type CaseInput = InferCaseInput<typeof built>;
+  const _inputIsExactlyNeeds: [CaseInput] extends [Needs]
+    ? [Needs] extends [CaseInput]
+      ? true
+      : false
+    : false = true;
+  void _inputIsExactlyNeeds;
+
+  // The whole `.case()` I/O chain still works off the built case.
+  const preContract = api("user.create.preannotated", {
+    endpoint: "POST /users",
+    cases: { ok: built },
+  });
+  const preRef = preContract.case("ok");
+  type PreRefInput = typeof preRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _preRefInput: PreRefInput = { email: "a@b.c" };
+  // @ts-expect-error — the ref input is Needs, not `any`/`never`.
+  const _preRefInputNotAny: PreRefInput = { completelyWrongField: "x" };
+  void _preRefInput;
+  void _preRefInputNotAny;
+
+  // NOTE the deliberate non-assertion: annotating the body as
+  // `HttpCaseBody<Needs>` WIDENS the literal, so `expect.schema` presence is
+  // erased and `ExtractCaseResponse` is `unknown` on this path. That is the
+  // cost of pre-annotating, not a regression — the inline-literal path (5.3)
+  // is what keeps the typed response.
+  const _preAnnotatedResponseIsUnknown: [unknown] extends [
+    ExtractCaseResponse<typeof built>,
+  ]
+    ? true
+    : false = true;
+  void _preAnnotatedResponseIsUnknown;
 }

--- a/packages/sdk/src/attachment-model.test-d.ts
+++ b/packages/sdk/src/attachment-model.test-d.ts
@@ -281,3 +281,153 @@ import { defineHttpCase } from "./index.js";
   });
   void _drift2;
 }
+
+// =============================================================================
+// Test 5: httpCase(schema)(case) — the curried factory. Same drift guard as
+// defineHttpCase, but with NOTHING defaulted: `N` is inferred from the schema
+// VALUE (first call) and `C` from the case literal (second call). So the case
+// keeps its literal type — `expect.schema` presence included — and flow
+// `res.body` stays typed, which defineHttpCase's nominal return erases.
+// =============================================================================
+
+import { httpCase } from "./index.js";
+import type { ContractCase } from "./index.js";
+import type { ExtractCaseResponse } from "./contract-types.js";
+
+{
+  // ---------------------------------------------------------------------
+  // 5.1 Positive contextual typing: the action-field param IS the schema's
+  // output type — inferred, never annotated.
+  // ---------------------------------------------------------------------
+  const _typedInput = httpCase(s<{ email: string; token: string }>())({
+    description: "creates user",
+    body: (input) => {
+      // Proves `input` is `{email, token}` and NOT implicitly `any` (which
+      // would make the 5.2 drift assertions vacuous).
+      const email: string = input.email;
+      return { email };
+    },
+    headers: ({ token }) => ({ authorization: `Bearer ${token}` }),
+    pathParams: ({ email }) => ({ email }),
+    query: ({ token }) => ({ token }),
+    // `verify`'s `res` is not inferred from expect.schema — annotate to type it.
+    verify: async (_ctx, res: { name: string }) => {
+      void res.name;
+    },
+    expect: { status: 201, schema: s<{ name: string }>() },
+  });
+  void _typedInput;
+
+  // ---------------------------------------------------------------------
+  // 5.2 Drift guard: a key that is not on the schema is a compile error on
+  // every action field (body / pathParams shown).
+  // ---------------------------------------------------------------------
+  const _driftBody = httpCase(s<{ email: string }>())({
+    description: "body drift",
+    // @ts-expect-error — `wrongKey` is not on Needs `{email: string}`.
+    body: ({ wrongKey }) => ({ wrongKey }),
+    expect: { status: 200 },
+  });
+  void _driftBody;
+
+  const _driftPathParams = httpCase(s<{ userId: string }>())({
+    description: "pathParams drift",
+    // @ts-expect-error — `wrongKey` is not on Needs `{userId: string}`.
+    pathParams: ({ wrongKey }) => ({ wrongKey }),
+    expect: { status: 200 },
+  });
+  void _driftPathParams;
+
+  // ---------------------------------------------------------------------
+  // 5.3 Typed response preserved: `expect.schema` survives into the case's
+  // type, so core's ExtractCaseResponse resolves the body — the motivation
+  // for the curried shape.
+  // ---------------------------------------------------------------------
+  const schemaCase = httpCase(s<{ email: string }>())({
+    description: "returns a named thing",
+    body: ({ email }) => ({ email }),
+    expect: { status: 200, schema: s<{ name: string }>() },
+  });
+
+  type CurriedResponse = ExtractCaseResponse<typeof schemaCase>;
+  const _responseIsTyped: CurriedResponse = { name: "n" };
+  // @ts-expect-error — response is `{name: string}`, so a wrong shape fails.
+  const _responseNotAny: CurriedResponse = { wrong: 1 };
+  // `unknown` is only assignable TO `unknown` — false here proves it resolved.
+  const _responseNotUnknown: [unknown] extends [CurriedResponse] ? true : false = false;
+  void _responseIsTyped;
+  void _responseNotAny;
+  void _responseNotUnknown;
+
+  // Contrast — the same case through defineHttpCase degrades to `unknown`,
+  // because its nominal `ContractCase<T, Needs>` return has `expect.schema?:`
+  // OPTIONAL while ExtractCaseResponse matches `schema` as REQUIRED.
+  const nominalCase = defineHttpCase<{ email: string }, { name: string }>({
+    description: "returns a named thing",
+    needs: s<{ email: string }>(),
+    body: ({ email }) => ({ email }),
+    expect: { status: 200, schema: s<{ name: string }>() },
+  });
+  const _nominalIsUnknown: [unknown] extends [
+    ExtractCaseResponse<typeof nominalCase>,
+  ]
+    ? true
+    : false = true;
+  void _nominalIsUnknown;
+
+  // ---------------------------------------------------------------------
+  // 5.4 Single declaration site: `needs` belongs to the factory call, never
+  // to the case literal (runtime throws on it too).
+  // ---------------------------------------------------------------------
+  const _doubleDeclared = httpCase(s<{ email: string }>())({
+    description: "declares needs twice",
+    // @ts-expect-error — `needs` is owned by the factory; HttpCaseBody pins
+    // the field to `never` so writing it here cannot compile.
+    needs: s<{ email: string }>(),
+    expect: { status: 200 },
+  });
+  void _doubleDeclared;
+
+  // ---------------------------------------------------------------------
+  // 5.5 Zero-arg form for cases with no logical input.
+  // ---------------------------------------------------------------------
+  const noNeedsCase = httpCase()({
+    description: "no content",
+    expect: { status: 204 },
+  });
+  const _assignableAsCase: ContractCase = noNeedsCase;
+  void _assignableAsCase;
+
+  // Still one declaration site in the zero-arg form.
+  const _zeroArgDoubleDeclared = httpCase()({
+    description: "declares needs without a factory schema",
+    // @ts-expect-error — `needs` is owned by the factory in BOTH forms.
+    needs: s<{ email: string }>(),
+    expect: { status: 204 },
+  });
+  void _zeroArgDoubleDeclared;
+
+  // ---------------------------------------------------------------------
+  // 5.6 The returned case is accepted by the real contract factory, and the
+  // resulting `.case()` ref carries the schema-typed body.
+  // ---------------------------------------------------------------------
+  const users = api("user.create", {
+    endpoint: "POST /users",
+    cases: { ok: schemaCase, noContent: noNeedsCase },
+  });
+
+  const okRef = users.case("ok");
+
+  // Needs threads through to the ref's phantom input.
+  type OkInput = typeof okRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _okInput: OkInput = { email: "a@b.c" };
+  // @ts-expect-error — proves the ref input is Needs, not `any`.
+  const _okInputNotAny: OkInput = { completelyWrongField: "x" };
+  void _okInput;
+  void _okInputNotAny;
+
+  // Flow lens output: `res.body` is typed from the case's `expect.schema`.
+  type OkOutput = typeof okRef extends { __phantom_output?: infer O } ? O : never;
+  const _okBodyName: string = ({} as OkOutput).body.name;
+  void _okBodyName;
+}

--- a/packages/sdk/src/contract-http/http-case.test.ts
+++ b/packages/sdk/src/contract-http/http-case.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Runtime behavior of the `httpCase` curried case factory.
+ *
+ * The factory is a TYPING device (it correlates `needs` with the function-valued
+ * action fields TypeScript can't correlate across sibling literal fields), so its
+ * runtime job is deliberately tiny: attach the schema, and keep the schema's
+ * single declaration site enforceable for JavaScript consumers too.
+ *
+ * Compile-time behavior (drift guard, preserved `expect.schema` typing) lives in
+ * `../attachment-model.test-d.ts` Test 5.
+ */
+
+import { test, expect } from "vitest";
+import { httpCase } from "../index.js";
+import type { SchemaLike } from "../types.js";
+
+/** Minimal SchemaLike — identity parse is enough; nothing here validates. */
+const needsSchema: SchemaLike<{ email: string }> = {
+  safeParse: (d: unknown) => ({ success: true as const, data: d as { email: string } }),
+} as SchemaLike<{ email: string }>;
+
+test("httpCase(schema)(case) returns a new object carrying the schema as `needs`", () => {
+  const body = ({ email }: { email: string }) => ({ email });
+  const spec = {
+    description: "creates a user",
+    body,
+    expect: { status: 201 },
+  } as const;
+
+  const built = httpCase(needsSchema)(spec);
+
+  // New object — the input literal is never mutated.
+  expect(built).not.toBe(spec);
+  // Every authored field survives, by reference for the function-valued ones.
+  expect(built.description).toBe("creates a user");
+  expect(built.body).toBe(body);
+  expect(built.expect).toEqual({ status: 201 });
+  // ...plus the schema the factory owns, by reference.
+  expect(built.needs).toBe(needsSchema);
+
+  // Value-identical to writing `needs` inside the case literal — migrating an
+  // existing case must not move its projection or canonicalHash.
+  expect({ ...built }).toEqual({ ...spec, needs: needsSchema });
+});
+
+test("httpCase()(case) returns the case unchanged", () => {
+  const spec = {
+    description: "no content",
+    expect: { status: 204 },
+  } as const;
+
+  const built = httpCase()(spec);
+
+  expect(built.description).toBe("no content");
+  expect(built.expect).toEqual({ status: 204 });
+  expect(Object.prototype.hasOwnProperty.call(built, "needs")).toBe(false);
+  expect({ ...built }).toEqual({ ...spec });
+});
+
+// A literal `needs` is a compile error (`HttpCaseBody` pins the field to
+// `never`); these casts reproduce what an untyped JavaScript consumer can still
+// write, and assert the runtime refuses it in BOTH forms.
+type UntypedCaseFactory = (c: Record<string, unknown>) => unknown;
+
+test("literal `needs` in the case throws — schema form", () => {
+  const build = httpCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs twice",
+      needs: needsSchema,
+      expect: { status: 200 },
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+test("literal `needs` in the case throws — zero-arg form", () => {
+  const build = httpCase() as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs without a factory schema",
+      needs: needsSchema,
+      expect: { status: 204 },
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+test("the throw names the one supported declaration site", () => {
+  const build = httpCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({ description: "x", needs: needsSchema, expect: { status: 200 } }),
+  ).toThrow(/httpCase\(schema\)\(\{ \.\.\. \}\)/);
+});

--- a/packages/sdk/src/contract-http/http-case.test.ts
+++ b/packages/sdk/src/contract-http/http-case.test.ts
@@ -86,6 +86,29 @@ test("literal `needs` in the case throws — zero-arg form", () => {
   ).toThrow(/do not declare `needs` inside the case literal/);
 });
 
+// An explicit `needs: undefined` declares nothing, and the type layer admits it
+// (`needs?: never` + no `exactOptionalPropertyTypes`). The runtime must agree —
+// every reader of the field treats undefined as "no needs declared".
+test("`needs: undefined` is tolerated — schema form overwrites it", () => {
+  const built = httpCase(needsSchema)({
+    description: "explicit undefined",
+    needs: undefined,
+    expect: { status: 200 },
+  });
+
+  expect(built.needs).toBe(needsSchema);
+});
+
+test("`needs: undefined` is tolerated — zero-arg form leaves it undefined", () => {
+  const built = httpCase()({
+    description: "explicit undefined, no factory schema",
+    needs: undefined,
+    expect: { status: 204 },
+  });
+
+  expect(built.needs).toBeUndefined();
+});
+
 test("the throw names the one supported declaration site", () => {
   const build = httpCase(needsSchema) as unknown as UntypedCaseFactory;
 

--- a/packages/sdk/src/contract-http/index.ts
+++ b/packages/sdk/src/contract-http/index.ts
@@ -26,10 +26,11 @@ export type {
   SignatureVerifyResult,
 } from "./inbound-verify.js";
 export { createHttpFactory, createHttpRoot } from "./factory.js";
-export { defineHttpCase } from "./types.js";
+export { defineHttpCase, httpCase } from "./types.js";
 
 export type {
   // User-facing authoring types
+  HttpCaseBody,
   HttpContractSpec,
   HttpContractDefaults,
   HttpSecurityScheme,

--- a/packages/sdk/src/contract-http/types.ts
+++ b/packages/sdk/src/contract-http/types.ts
@@ -201,7 +201,9 @@ export function defineHttpCase<Needs = void, T = unknown>(
  * excess-property check against a type parameter's CONSTRAINT, so a bare
  * `Omit<...>` would silently absorb a stray `needs` key into the inferred case
  * type and leave two competing declarations of the same schema. The `never`
- * makes writing it a compile error at the offending property.
+ * makes writing a schema there a compile error at the offending property. An
+ * explicit `needs: undefined` still passes — `exactOptionalPropertyTypes` is
+ * off in this repo and it declares nothing anyway.
  */
 export type HttpCaseBody<N> = Omit<ContractCase<any, N>, "needs"> & {
   needs?: never;
@@ -233,12 +235,17 @@ export type HttpCaseBody<N> = Omit<ContractCase<any, N>, "needs"> & {
  *   presence of `expect.schema` — so core's `ExtractCaseResponse` /
  *   `ApplyCaseOutput` type a `.call`/`.poll` lens's `res.body` from that schema
  *   instead of degrading it to `unknown`.
- * - **One declaration site.** A `needs` key inside the case literal is both a
- *   compile error (see {@link HttpCaseBody}) and a runtime `Error`.
+ * - **One declaration site.** A `needs` SCHEMA inside the case literal is both a
+ *   compile error (see {@link HttpCaseBody}) and a runtime `Error`. The one
+ *   tolerated form is an explicit `needs: undefined`, which declares nothing:
+ *   `exactOptionalPropertyTypes` is off here, so `needs?: never` admits it, and
+ *   every runtime reader already treats undefined as "no needs" — rejecting it
+ *   would make the type layer and the runtime promise different things.
  *
- * Runtime output is VALUE-IDENTICAL to writing `needs` in the case literal (the
- * factory only spreads the schema in), so migrating an existing case moves
- * neither its projection nor its `canonicalHash`.
+ * Runtime output is VALUE-IDENTICAL to the pre-migration shape — a case that
+ * declared `needs` inline — because the factory only spreads the schema back
+ * in. Migrating an existing case moves neither its projection nor its
+ * `canonicalHash`.
  *
  * `verify(ctx, res)`'s `res` is not inferred from `expect.schema` — that would
  * need a second inference pass over the same literal. Annotate the parameter
@@ -277,18 +284,35 @@ export type HttpCaseBody<N> = Omit<ContractCase<any, N>, "needs"> & {
  */
 export function httpCase<N>(
   needs: SchemaLike<N>,
-): <const C extends HttpCaseBody<N>>(c: C) => C & { needs: SchemaLike<N> };
+): <const C extends HttpCaseBody<N>>(
+  c: C,
+  // `Omit<C, "needs">` before the intersection, never a bare `C & {...}`: a case
+  // written against the exported `HttpCaseBody<X>` annotation carries the
+  // `needs?: never` guard INTO `C`, and intersecting that with the required
+  // `needs: SchemaLike<N>` collapses the property (and with it `InferCaseInput`)
+  // to `never`. Dropping the guarded key first keeps every other property's
+  // literal type intact, so `expect.schema` still types flow `res.body`.
+) => Omit<C, "needs"> & { needs: SchemaLike<N> };
 export function httpCase(): <const C extends HttpCaseBody<void>>(c: C) => C;
 export function httpCase(needs?: SchemaLike<unknown>) {
   // Keep JS consumers aligned with the type-level `needs?: never` — a literal
-  // `needs` key is a hard error in BOTH forms, so the schema always has exactly
-  // one declaration site. The zero-arg form returns the case unchanged.
+  // `needs` SCHEMA is a hard error in BOTH forms, so it always has exactly one
+  // declaration site. The zero-arg form returns the case unchanged.
   //
   // The two overloads above are the checked authoring surface; this
   // implementation is untyped glue (a concrete param type is not compatible
   // with both of them).
   return (c: any) => {
-    if (Object.prototype.hasOwnProperty.call(c, "needs")) {
+    // Value check, NOT hasOwnProperty: `exactOptionalPropertyTypes` is off in
+    // this repo, so `needs?: never` accepts an explicit `needs: undefined` and
+    // the runtime must accept it too, or the two layers promise different
+    // things. Tolerating it is safe because every runtime reader treats
+    // undefined as "no needs declared": core's §5.1 branches are falsy checks
+    // (`contract-core.ts` `if (!needsSchema)` / `if (needsSchema)`), the
+    // projection records `hasNeeds: c.needs !== undefined`, and the inbound
+    // field guard also compares `!== undefined`. In the schema form the spread
+    // below overwrites the key anyway.
+    if (c.needs !== undefined) {
       throw new Error(
         "httpCase: do not declare `needs` inside the case literal — the factory " +
           "owns that field. Declare it once as `httpCase(schema)({ ... })` and " +

--- a/packages/sdk/src/contract-http/types.ts
+++ b/packages/sdk/src/contract-http/types.ts
@@ -154,8 +154,15 @@ export type HttpStaticBody =
  * `defineHttpCase(...)` returns the nominal `ContractCase<T, Needs>` (which erases
  * schema presence for drift-locking), so a case routed through it leaves flow
  * `res.body` as `unknown` — that's the trade for its compile-time case-shape +
- * needs-drift checks. Use inline cases for typed flow lenses; use `defineHttpCase`
- * when you want the action-field drift guard.
+ * needs-drift checks. {@link httpCase} resolves the trade: because its curried
+ * shape lets TS INFER every type parameter, the case keeps its literal type
+ * (`expect.schema` presence included) AND the drift guard. Prefer it; reach for
+ * inline cases only when you don't need the guard.
+ *
+ * @deprecated Use {@link httpCase} — same drift guard with zero explicit
+ * generics, and it preserves typed flow `res.body`. Before:
+ * `defineHttpCase<{ email: string }>({ needs: Schema, body: ({ email }) => ... })`;
+ * after: `httpCase(Schema)({ body: ({ email }) => ... })`.
  *
  * @example
  * ```ts
@@ -184,6 +191,112 @@ export function defineHttpCase<Needs = void, T = unknown>(
   c: ContractCase<T, Needs>,
 ): ContractCase<T, Needs> {
   return c;
+}
+
+/**
+ * Case body for {@link httpCase} — `ContractCase` WITHOUT `needs`; the factory
+ * owns that field.
+ *
+ * `needs` is pinned to `never` rather than merely omitted: TypeScript runs no
+ * excess-property check against a type parameter's CONSTRAINT, so a bare
+ * `Omit<...>` would silently absorb a stray `needs` key into the inferred case
+ * type and leave two competing declarations of the same schema. The `never`
+ * makes writing it a compile error at the offending property.
+ */
+export type HttpCaseBody<N> = Omit<ContractCase<any, N>, "needs"> & {
+  needs?: never;
+};
+
+/**
+ * Curried HTTP case factory — {@link defineHttpCase}'s needs-drift guard with
+ * zero explicit generics, and without its typed-response trade. Prefer this.
+ *
+ * **Why curried.** TypeScript can't correlate sibling fields of one object
+ * literal, so `needs: SchemaLike<X>` never types the `body: (input) => ...`
+ * written beside it — a factory has to capture `Needs` first. But TS also has
+ * no PARTIAL type-argument inference: the moment an author writes
+ * `defineHttpCase<Needs>(...)`, every remaining type parameter falls back to
+ * its default and the case widens to the nominal `ContractCase<T, Needs>`.
+ * Splitting the call in two leaves nothing to default — `N` is inferred from
+ * the schema VALUE in the first call, `C` from the case literal in the second
+ * (contextually typed by `HttpCaseBody<N>`, which is what still threads `N`
+ * into the action fields).
+ *
+ * What that buys over `defineHttpCase`:
+ * - **No explicit generics.** The schema is written once, as a value, and the
+ *   whole case is checked against it.
+ * - **Drift guard on all four action fields** — `body` / `pathParams` / `query`
+ *   / `headers` (plus the deprecated `params` alias) take `(input: N) => ...`,
+ *   so destructuring a key that isn't on `N` is a compile error instead of a
+ *   silently `undefined` field in the outgoing request.
+ * - **Typed flow `res.body`.** The case keeps its LITERAL type — including the
+ *   presence of `expect.schema` — so core's `ExtractCaseResponse` /
+ *   `ApplyCaseOutput` type a `.call`/`.poll` lens's `res.body` from that schema
+ *   instead of degrading it to `unknown`.
+ * - **One declaration site.** A `needs` key inside the case literal is both a
+ *   compile error (see {@link HttpCaseBody}) and a runtime `Error`.
+ *
+ * Runtime output is VALUE-IDENTICAL to writing `needs` in the case literal (the
+ * factory only spreads the schema in), so migrating an existing case moves
+ * neither its projection nor its `canonicalHash`.
+ *
+ * `verify(ctx, res)`'s `res` is not inferred from `expect.schema` — that would
+ * need a second inference pass over the same literal. Annotate the parameter
+ * when you want it typed; the schema still validates the response at runtime.
+ *
+ * @example
+ * ```ts
+ * import { contract, httpCase, workflow } from "@glubean/sdk";
+ * import { z } from "zod";
+ *
+ * const createUser = httpCase(z.object({ email: z.string(), token: z.string() }))({
+ *   description: "creates a user",
+ *   // `input` is { email: string; token: string } — inferred, never annotated.
+ *   body: ({ email }) => ({ email }),
+ *   headers: ({ token }) => ({ authorization: `Bearer ${token}` }),
+ *   expect: { status: 201, schema: z.object({ id: z.string() }) },
+ * });
+ *
+ * const api = contract.http.with("users", { client });
+ * export const users = api("user.create", {
+ *   endpoint: "POST /users",
+ *   cases: { createUser },
+ * });
+ *
+ * // ...and the flow lens sees the schema: `res.body` is { id: string }.
+ * workflow("signup").call("create", users.case("createUser"), {
+ *   in: () => ({ email: "a@b.c", token: "t" }),
+ *   out: (state, res) => ({ ...state, userId: res.body.id }),
+ * });
+ * ```
+ *
+ * @param needs The case's logical input schema — declared here, exactly once.
+ *   Omit the argument entirely for a case with no logical input; that form
+ *   returns the case unchanged and still rejects a literal `needs`.
+ * @returns A function taking the case literal, returning it with `needs` attached.
+ */
+export function httpCase<N>(
+  needs: SchemaLike<N>,
+): <const C extends HttpCaseBody<N>>(c: C) => C & { needs: SchemaLike<N> };
+export function httpCase(): <const C extends HttpCaseBody<void>>(c: C) => C;
+export function httpCase(needs?: SchemaLike<unknown>) {
+  // Keep JS consumers aligned with the type-level `needs?: never` — a literal
+  // `needs` key is a hard error in BOTH forms, so the schema always has exactly
+  // one declaration site. The zero-arg form returns the case unchanged.
+  //
+  // The two overloads above are the checked authoring surface; this
+  // implementation is untyped glue (a concrete param type is not compatible
+  // with both of them).
+  return (c: any) => {
+    if (Object.prototype.hasOwnProperty.call(c, "needs")) {
+      throw new Error(
+        "httpCase: do not declare `needs` inside the case literal — the factory " +
+          "owns that field. Declare it once as `httpCase(schema)({ ... })` and " +
+          "remove `needs` from the case object.",
+      );
+    }
+    return needs === undefined ? c : { ...c, needs };
+  };
 }
 
 export interface ContractCase<T = unknown, Needs = void> extends BaseCaseSpec {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -587,8 +587,9 @@ export {
   createHttpFactory,
   createHttpRoot,
 } from "./contract-http/factory.js";
-export { defineHttpCase } from "./contract-http/types.js";
+export { defineHttpCase, httpCase } from "./contract-http/types.js";
 export type {
+  HttpCaseBody,
   HttpContractSpec,
   HttpContractDefaults,
   HttpSecurityScheme,


### PR DESCRIPTION
Fixes #27

## What

Adds `httpCase(needsSchema)(caseSpec)` — a curried HTTP case factory — and deprecates `defineHttpCase` in its favor. Also updates the `migrate` command's `needs-factory` advice to recommend the new factory (with the structural move+remove steps spelled out) and teaches its already-wrapped check to recognize the curried callee.

## Why

`defineHttpCase<Needs, T>` forces a choice authors shouldn't have to make. TypeScript cannot correlate sibling fields of one object literal, and has no partial type-argument inference — so the old factory needs explicit generics and must return the widened nominal `ContractCase<T, Needs>`, whose optional `expect.schema` erases typed flow `res.body` (core's `ExtractCaseResponse` matches `schema` as a required key). Inline literals keep the typed body but lose the needs-drift guard.

The curried shape leaves nothing to default: `N` is inferred from the schema value in the first call, the literal `C` (contextually typed by `HttpCaseBody<N>`) in the second. The case keeps its literal type, so the drift guard and the typed lens body hold simultaneously. Runtime output is value-identical to the pre-migration shape, so migrating a case moves neither its projection nor its `canonicalHash`.

## Notable design points

- `HttpCaseBody<N>` pins `needs?: never` — constraints get no excess-property check, so a bare `Omit` would silently absorb a stray `needs` key.
- The schema form returns `Omit<C, "needs"> & { needs: SchemaLike<N> }` (drop-then-attach): a case body pre-annotated with the exported `HttpCaseBody<N>` carries the guard into `C`, and a bare intersection would collapse the property to `never`.
- The runtime guard is a value check (`c.needs !== undefined`), matching what the type layer admits with `exactOptionalPropertyTypes` off — every runtime reader already treats undefined as "no needs declared".
- `verify(ctx, res)`'s `res` is not inferred from `expect.schema` (documented; annotate when needed).

## Out of scope

`defineGraphqlCase` / `defineGrpcCase` / `defineBrowserCase` parity (follow-up), docs-site updates, downstream migrations.

## Verification

- `CI=1 pnpm -r build` and `CI=1 pnpm -r test` green on the full workspace (sdk 718, cli 627).
- Type-level assertions in `attachment-model.test-d.ts` Test 5.1–5.7 (drift guard both directions, `ExtractCaseResponse` preservation with a `defineHttpCase` degradation contrast, literal-`needs` rejection, zero-arg form, end-to-end through the contract factory, pre-annotated-body regression), verified via `tsc -p packages/sdk/tsconfig.json --noEmit` (zero errors in touched files).
- Runtime behavior covered in `packages/sdk/src/contract-http/http-case.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)