### PR TITLE
plugins: curried graphqlCase / grpcCase / browserCase — protocol parity with httpCase

### DIFF
--- a/packages/browser/guides/chrome-extension/sidepanel.md
+++ b/packages/browser/guides/chrome-extension/sidepanel.md
@@ -52,18 +52,23 @@ document. It is intentionally outside the host page's single-page evidence
 window; use imperative assertions inside the step action. Declarative
 multi-page `contract.browser expect[]` support is a separate concern.
 
-The same capability is inferred for extension-backed browser contracts:
+The same capability is inferred for extension-backed browser contracts — the
+scoped client fixes the page type, so `page.extension` is available inside a step
+action with no explicit generics:
 
 ```ts
 import { contract } from "@glubean/sdk";
-import { defineBrowserCase } from "@glubean/browser";
+import { browserCase } from "@glubean/browser";
 import { chrome } from "./setup.js";
 
 const extensionUI = contract.browser.with("extensionUI", { client: chrome });
 
 export const nativeSidePanelLifecycle = extensionUI("native-side-panel-lifecycle", {
   cases: {
-    openCloseReopen: defineBrowserCase({
+    // `browserCase()` — the zero-argument form, for a journey with no logical
+    // input. A journey that takes input declares its schema once, in that call:
+    // `browserCase(schema)({ ... })`.
+    openCloseReopen: browserCase()({
       description: "The toolbar action opens, closes, and reopens the native side panel.",
       steps: [{
         id: "open-close-reopen",

--- a/packages/browser/src/contract/browser-case.test.ts
+++ b/packages/browser/src/contract/browser-case.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Runtime behavior of the `browserCase` curried case factory.
+ *
+ * The factory is a TYPING device (it correlates `needs` with the function-valued
+ * journey fields TypeScript can't correlate across sibling literal fields), so
+ * its runtime job is deliberately tiny: attach the schema, and keep the schema's
+ * single declaration site enforceable for JavaScript consumers too.
+ *
+ * Compile-time behavior (drift guard, PageType inference) lives in
+ * `./types.test-d.ts`.
+ */
+
+import { test, expect } from "vitest";
+import { browserCase } from "../index.js";
+import type { SchemaLike } from "@glubean/sdk";
+
+/** Minimal SchemaLike — identity parse is enough; nothing here validates. */
+const needsSchema: SchemaLike<{ email: string }> = {
+  safeParse: (d: unknown) => ({ success: true as const, data: d as { email: string } }),
+} as SchemaLike<{ email: string }>;
+
+test("browserCase(schema)(case) returns a new object carrying the schema as `needs`", () => {
+  const action = async () => {};
+  const steps = [{ id: "submit", intent: "submit the form", action }];
+  const spec = {
+    description: "a returning user signs in",
+    entry: "/login",
+    steps,
+  };
+
+  const built = browserCase(needsSchema)(spec);
+
+  // New object — the input literal is never mutated.
+  expect(built).not.toBe(spec);
+  // Every authored field survives, by reference for the function-valued ones.
+  expect(built.description).toBe("a returning user signs in");
+  expect(built.entry).toBe("/login");
+  expect(built.steps).toBe(steps);
+  expect(built.steps[0]!.action).toBe(action);
+  // ...plus the schema the factory owns, by reference.
+  expect(built.needs).toBe(needsSchema);
+
+  // Value-identical to writing `needs` inside the case literal — migrating an
+  // existing case must not move its projection or canonicalHash.
+  expect({ ...built }).toEqual({ ...spec, needs: needsSchema });
+});
+
+test("browserCase()(case) returns the case unchanged", () => {
+  const spec = {
+    description: "an anonymous visitor reaches the landing page",
+    steps: [{ id: "visit", intent: "open the landing page" }],
+  };
+
+  const built = browserCase()(spec);
+
+  expect(built.description).toBe("an anonymous visitor reaches the landing page");
+  expect(built.steps).toBe(spec.steps);
+  expect(Object.prototype.hasOwnProperty.call(built, "needs")).toBe(false);
+  expect({ ...built }).toEqual({ ...spec });
+});
+
+// A literal `needs` is a compile error (`BrowserCaseBody` pins the field to
+// `never`); these casts reproduce what an untyped JavaScript consumer can still
+// write, and assert the runtime refuses it in BOTH forms.
+type UntypedCaseFactory = (c: Record<string, unknown>) => unknown;
+
+test("literal `needs` in the case throws — schema form", () => {
+  const build = browserCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs twice",
+      needs: needsSchema,
+      steps: [],
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+test("literal `needs` in the case throws — zero-arg form", () => {
+  const build = browserCase() as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs without a factory schema",
+      needs: needsSchema,
+      steps: [],
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+// An explicit `needs: undefined` declares nothing, and the type layer admits it
+// (`needs?: never` + no `exactOptionalPropertyTypes`). The runtime must agree —
+// every reader of the field treats undefined as "no needs declared".
+test("`needs: undefined` is tolerated — schema form overwrites it", () => {
+  const built = browserCase(needsSchema)({
+    description: "explicit undefined",
+    needs: undefined,
+    steps: [],
+  });
+
+  expect(built.needs).toBe(needsSchema);
+});
+
+test("`needs: undefined` is tolerated — zero-arg form leaves it undefined", () => {
+  const built = browserCase()({
+    description: "explicit undefined, no factory schema",
+    needs: undefined,
+    steps: [],
+  });
+
+  expect(built.needs).toBeUndefined();
+});
+
+test("the throw names the one supported declaration site", () => {
+  const build = browserCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({ description: "x", needs: needsSchema, steps: [] }),
+  ).toThrow(/browserCase\(schema\)\(\{ \.\.\. \}\)/);
+});

--- a/packages/browser/src/contract/index.ts
+++ b/packages/browser/src/contract/index.ts
@@ -19,7 +19,7 @@ export {
   resolveLocator,
   describeLocator,
 } from "./matchers.js";
-export { defineBrowserCase } from "./types.js";
+export { browserCase, defineBrowserCase } from "./types.js";
 export { judgeRecordedExpects, sealQaReport } from "./qa-recorder.js";
 export type {
   AgentQaReport,
@@ -30,6 +30,7 @@ export type {
   SealQaRunInput,
 } from "./qa-recorder.js";
 export type {
+  BrowserCaseBody,
   BrowserConsoleError,
   BrowserContractCase,
   BrowserContractDefaults,

--- a/packages/browser/src/contract/types.test-d.ts
+++ b/packages/browser/src/contract/types.test-d.ts
@@ -1,0 +1,337 @@
+/**
+ * Type-level tests for browser contract case factories.
+ *
+ * These are compile-only checks. They prove the curried
+ * `browserCase(schema)(case)` locks the logical input shape across `needs`,
+ * `steps[].action`, and `verify` with NOTHING defaulted: `N` is inferred from
+ * the schema VALUE (first call) and `C` from the case literal (second call).
+ *
+ * Browser journeys have no per-case response schema (no `expect.schema`, no
+ * `__caseOutputShape` marker — see `BrowserFlowCaseOutput`), so the
+ * "preserved type" axis here is `PageType` instead: the capability surface of
+ * `steps[].action`'s `page`, which must survive both inference routes.
+ */
+
+import { contract } from "@glubean/sdk";
+import type { SchemaLike } from "@glubean/sdk";
+import { browserCase, defineBrowserCase } from "../index.js";
+import type {
+  BrowserCaseBody,
+  BrowserContractCase,
+  BrowserPageClient,
+  InstrumentedPage,
+} from "../index.js";
+import type { ExtensionPage } from "../chrome-extension/index.js";
+
+function s<T>(): SchemaLike<T> {
+  return {} as SchemaLike<T>;
+}
+
+declare const client: BrowserPageClient<InstrumentedPage>;
+declare const chrome: BrowserPageClient<ExtensionPage>;
+
+const app = contract.browser.with("app", { client });
+const ext = contract.browser.with("ext", { client: chrome });
+
+{
+  // ---------------------------------------------------------------------
+  // 1. Positive contextual typing: the action / verify input IS the schema's
+  // output type — inferred, never annotated.
+  // ---------------------------------------------------------------------
+  const typedInput = browserCase(s<{ email: string; password: string }>())({
+    description: "a returning user signs in",
+    entry: "/login",
+    steps: [
+      {
+        id: "submit",
+        intent: "fill the credentials and submit",
+        action: async (page, input) => {
+          // Proves `input` is `{email, password}` and NOT implicitly `any`
+          // (which would make the drift assertions below vacuous).
+          const email: string = input.email;
+          void email;
+          void input.password;
+          // ...and that the default page keeps its instrumented surface.
+          void page.url();
+        },
+      },
+    ],
+    expect: [{ id: "lands-on-dashboard", url: { path: "/dashboard" } }],
+    verify: (_ctx, evidence, input) => {
+      const email: string = input.email;
+      void email;
+      void evidence.finalUrl;
+    },
+  });
+  void typedInput;
+
+  // ---------------------------------------------------------------------
+  // 2. Drift guard: a key that is not on the schema is a compile error in
+  // both function-valued positions.
+  // ---------------------------------------------------------------------
+  const _driftAction = browserCase(s<{ email: string }>())({
+    description: "action drift",
+    steps: [
+      {
+        id: "s1",
+        intent: "i",
+        // @ts-expect-error -- `wrongKey` is not on Needs `{email: string}`.
+        action: async (_page, { wrongKey }) => {
+          void wrongKey;
+        },
+      },
+    ],
+  });
+  void _driftAction;
+
+  const _driftVerify = browserCase(s<{ email: string }>())({
+    description: "verify drift",
+    steps: [],
+    // @ts-expect-error -- `wrongKey` is not on Needs `{email: string}`.
+    verify: (_ctx, _evidence, { wrongKey }) => {
+      void wrongKey;
+    },
+  });
+  void _driftVerify;
+
+  // ---------------------------------------------------------------------
+  // 3. PageType preserved — route A: the ENCLOSING contract's client fixes it,
+  // and it is pinned before the `action` bodies are checked.
+  // ---------------------------------------------------------------------
+  const _extInline = ext("extension.sidepanel", {
+    cases: {
+      openPanel: browserCase(s<{ email: string }>())({
+        description: "the toolbar action opens the side panel",
+        steps: [
+          {
+            id: "open",
+            intent: "open the native side panel",
+            action: async (page, input) => {
+              void input.email;
+              // Only compiles when PageType inferred as ExtensionPage.
+              const handle = await page.extension.sidePanel.open();
+              await handle.close();
+            },
+          },
+        ],
+      }),
+    },
+  });
+  void _extInline;
+
+  // Route B: the case's OWN `client` fixes it, with no enclosing contract.
+  const _extStandalone = browserCase(s<{ email: string }>())({
+    description: "standalone case pinned by its own client",
+    client: chrome,
+    steps: [
+      {
+        id: "open",
+        intent: "open the native side panel",
+        action: async (page, input) => {
+          void input.email;
+          const handle = await page.extension.sidePanel.open();
+          await handle.close();
+        },
+      },
+    ],
+  });
+  void _extStandalone;
+
+  // Neither route: PageType falls back to InstrumentedPage. This is the one
+  // shape `defineBrowserCase<Input, PageType>` still expresses and
+  // `browserCase` does not — see the factories' JSDoc.
+  const _defaultPage = browserCase(s<{ email: string }>())({
+    description: "standalone, client-less",
+    steps: [
+      {
+        id: "s1",
+        intent: "i",
+        action: async (page, input) => {
+          void input.email;
+          // @ts-expect-error -- no page-type route: `extension` is not on
+          // InstrumentedPage.
+          void page.extension;
+        },
+      },
+    ],
+  });
+  void _defaultPage;
+
+  // A default-page case is still USABLE in an extension contract — an action
+  // that accepts the wider page accepts the narrower one (contravariance).
+  const _defaultInExt = ext("extension.reuse", {
+    cases: { ok: _defaultPage },
+  });
+  void _defaultInExt;
+
+  // ---------------------------------------------------------------------
+  // 4. Single declaration site: `needs` belongs to the factory call, never
+  // to the case literal (runtime throws on it too).
+  // ---------------------------------------------------------------------
+  const _doubleDeclared = browserCase(s<{ email: string }>())({
+    description: "declares needs twice",
+    // @ts-expect-error -- `needs` is owned by the factory; BrowserCaseBody pins
+    // the field to `never` so writing it here cannot compile.
+    needs: s<{ email: string }>(),
+    steps: [],
+  });
+  void _doubleDeclared;
+
+  // ...but an explicit `needs: undefined` DECLARES NOTHING and compiles:
+  // `exactOptionalPropertyTypes` is off, so `needs?: never` admits undefined.
+  // The runtime tolerates it for exactly this reason (see browser-case.test.ts)
+  // — the two layers must promise the same thing.
+  const _explicitUndefined = browserCase(s<{ email: string }>())({
+    description: "explicit undefined declares nothing",
+    needs: undefined,
+    steps: [
+      {
+        id: "s1",
+        intent: "i",
+        action: async (_page, { email }) => {
+          void email;
+        },
+      },
+    ],
+  });
+  void _explicitUndefined;
+
+  // ---------------------------------------------------------------------
+  // 5. Zero-arg form for journeys with no logical input — including inside an
+  // extension contract, where PageType still infers.
+  // ---------------------------------------------------------------------
+  const noNeedsCase = browserCase()({
+    description: "an anonymous visitor reaches the marketing page",
+    steps: [
+      {
+        id: "visit",
+        intent: "open the landing page",
+        action: async (page) => {
+          void page.url();
+        },
+      },
+    ],
+    expect: [{ id: "renders", dom: { visible: { role: "heading" } } }],
+  });
+  const _assignableAsCase: BrowserContractCase = noNeedsCase;
+  void _assignableAsCase;
+
+  const _zeroArgExtension = ext("extension.zero", {
+    cases: {
+      ok: browserCase()({
+        description: "no logical input, extension page",
+        steps: [
+          {
+            id: "open",
+            intent: "open the native side panel",
+            action: async (page) => {
+              const handle = await page.extension.sidePanel.open();
+              await handle.close();
+            },
+          },
+        ],
+      }),
+    },
+  });
+  void _zeroArgExtension;
+
+  // Still one declaration site in the zero-arg form.
+  const _zeroArgDoubleDeclared = browserCase()({
+    description: "declares needs without a factory schema",
+    // @ts-expect-error -- `needs` is owned by the factory in BOTH forms.
+    needs: s<{ email: string }>(),
+    steps: [],
+  });
+  void _zeroArgDoubleDeclared;
+
+  // ---------------------------------------------------------------------
+  // 6. The returned case is accepted by the real contract factory, and the
+  // resulting `.case()` ref carries the per-case Needs.
+  // ---------------------------------------------------------------------
+  const journeys = app("auth.signIn", {
+    cases: { signIn: typedInput, landing: noNeedsCase },
+  });
+
+  const signInRef = journeys.case("signIn");
+  type SignInInput = typeof signInRef extends { __phantom_inputs?: infer I }
+    ? I
+    : never;
+  const _signInInput: SignInInput = { email: "a@b.c", password: "pw" };
+  // @ts-expect-error -- proves the ref input is Needs, not `any`.
+  const _signInInputNotAny: SignInInput = { completelyWrongField: "x" };
+  void _signInInput;
+  void _signInInputNotAny;
+
+  // The deprecated factory keeps working (it is the escape hatch for a
+  // standalone, client-less, non-default-page case).
+  const _deprecated = defineBrowserCase<{ email: string }, ExtensionPage>({
+    description: "explicit generics, standalone",
+    needs: s<{ email: string }>(),
+    steps: [
+      {
+        id: "open",
+        intent: "open the native side panel",
+        action: async (page, input) => {
+          void input.email;
+          const handle = await page.extension.sidePanel.open();
+          await handle.close();
+        },
+      },
+    ],
+  });
+  void _deprecated;
+}
+
+// =============================================================================
+// Regression: a case body written against the EXPORTED `BrowserCaseBody<N>`
+// annotation must survive the factory.
+//
+// `BrowserCaseBody` carries the `needs?: never` single-declaration guard, so a
+// bare `C & { needs: SchemaLike<N> }` return type intersects `never` with a
+// required property and collapses `needs` — taking core's `InferCaseInput` (and
+// with it the whole `.case()` I/O chain) down to `never`. The return type drops
+// the guarded key first (`Omit<C, "needs" | "steps"> & ...`), which is what
+// these assert.
+// =============================================================================
+
+{
+  type Needs = { email: string };
+
+  const preAnnotated: BrowserCaseBody<Needs> = {
+    description: "pre-annotated case body",
+    steps: [
+      {
+        id: "s1",
+        intent: "submit the email",
+        action: async (_page, { email }) => {
+          void email;
+        },
+      },
+    ],
+  };
+
+  const built = browserCase(s<Needs>())(preAnnotated);
+
+  // `needs` must be the schema, NOT `never`.
+  const _needsUsable: SchemaLike<Needs> = built.needs;
+  const _needsNotNever: [(typeof built)["needs"]] extends [never] ? true : false = false;
+  // Other fields stay reachable (a collapsed intersection makes the whole
+  // object unusable, not just its `needs`).
+  const _descReachable: string = built.description;
+  void _needsUsable;
+  void _needsNotNever;
+  void _descReachable;
+
+  // The whole `.case()` I/O chain still works off the built case, and the ref's
+  // input is EXACTLY Needs — asserted both ways, since a one-way `extends` also
+  // holds for `never`.
+  const preContract = app("auth.signUp", { cases: { ok: built } });
+  const preRef = preContract.case("ok");
+  type PreRefInput = typeof preRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _inputIsExactlyNeeds: [PreRefInput] extends [Needs]
+    ? [Needs] extends [PreRefInput]
+      ? true
+      : false
+    : false = true;
+  void _inputIsExactlyNeeds;
+}

--- a/packages/browser/src/contract/types.test-d.ts
+++ b/packages/browser/src/contract/types.test-d.ts
@@ -188,8 +188,10 @@ const ext = contract.browser.with("ext", { client: chrome });
             intent: "open the native side panel",
             action: async (page) => {
               // @ts-expect-error - KNOWN GAP: spec.client does not drive
-              // PageType, so `page` is still InstrumentedPage here. Supported
-              // alternatives: `.with("x", { client })`, or a case-level client.
+              // PageType, so `page` is still InstrumentedPage here. The
+              // supported alternative is `.with("x", { client })`. A case-level
+              // client does NOT substitute — it types the case but cannot widen
+              // the contract it goes into (pinned below).
               await page.extension.sidePanel.open();
             },
           },
@@ -199,8 +201,8 @@ const ext = contract.browser.with("ext", { client: chrome });
   });
   void _specLevelClientGap;
 
-  // The two SUPPORTED alternatives for that same intent, pinned as the
-  // recommendation the docs point at (route 2 and route 1 respectively).
+  // The ONE supported alternative for that same intent (route 2), pinned as the
+  // recommendation the docs point at.
   const _specClientAlternativeWith = ext("spec-level-client.with", {
     cases: {
       ok: browserCase()({

--- a/packages/browser/src/contract/types.test-d.ts
+++ b/packages/browser/src/contract/types.test-d.ts
@@ -165,6 +165,90 @@ const ext = contract.browser.with("ext", { client: chrome });
   void _defaultInExt;
 
   // ---------------------------------------------------------------------
+  // 3b. KNOWN GAP, pinned deliberately: a client passed as the contract SPEC's
+  // `client` does NOT reach `PageType`. The route works at runtime, but
+  // `BrowserContractFactory` binds its page type at `.with(...)` time, so the
+  // spec literal is checked against an already-fixed type. Both attempted
+  // fixes (a per-call type parameter; an overload pair) demoted the page type
+  // to an unresolved type variable during contextual typing of `cases` and
+  // regressed the `.with({ client })` route above, so the gap stands.
+  //
+  // This assertion exists so that a future change CANNOT close (or further
+  // break) this silently — if the gap closes, the @ts-expect-error goes unused
+  // and this file fails to compile, forcing the docs to be updated with it.
+  // ---------------------------------------------------------------------
+  const _specLevelClientGap = app("spec-level-client", {
+    client: chrome,
+    cases: {
+      ok: browserCase()({
+        description: "spec-level client does not reach PageType",
+        steps: [
+          {
+            id: "open",
+            intent: "open the native side panel",
+            action: async (page) => {
+              // @ts-expect-error - KNOWN GAP: spec.client does not drive
+              // PageType, so `page` is still InstrumentedPage here. Supported
+              // alternatives: `.with("x", { client })`, or a case-level client.
+              await page.extension.sidePanel.open();
+            },
+          },
+        ],
+      }),
+    },
+  });
+  void _specLevelClientGap;
+
+  // The two SUPPORTED alternatives for that same intent, pinned as the
+  // recommendation the docs point at (route 2 and route 1 respectively).
+  const _specClientAlternativeWith = ext("spec-level-client.with", {
+    cases: {
+      ok: browserCase()({
+        description: "client on .with(...) — supported",
+        steps: [
+          {
+            id: "open",
+            intent: "open the native side panel",
+            action: async (page) => {
+              await page.extension.sidePanel.open();
+            },
+          },
+        ],
+      }),
+    },
+  });
+  void _specClientAlternativeWith;
+
+  // ...and the boundary of route 1, pinned: a case-level client types the case
+  // itself (see the standalone `_extStandalone` above), but it cannot UPGRADE
+  // the page type of the contract it is placed in — the contract's `Cases`
+  // constraint wants an action accepting the WIDER `InstrumentedPage`, and an
+  // `ExtensionPage`-accepting action is narrower (parameter contravariance).
+  // So for a spec-level client the only alternative is `.with(...)` above.
+  const caseLevelClientCase = browserCase()({
+    description: "client on the case",
+    client: chrome,
+    steps: [
+      {
+        id: "open",
+        intent: "open the native side panel",
+        action: async (page) => {
+          await page.extension.sidePanel.open();
+        },
+      },
+    ],
+  });
+  const _caseClientCannotUpgradeContract = app("spec-level-client.case", {
+    cases: {
+      // @ts-expect-error - a case-level ExtensionPage client does not widen the
+      // contract: `app` was created by `.with("app", { client })` on an
+      // InstrumentedPage client, so its cases must accept that wider page.
+      ok: caseLevelClientCase,
+    },
+  });
+  void _caseClientCannotUpgradeContract;
+
+  // ---------------------------------------------------------------------
   // 4. Single declaration site: `needs` belongs to the factory call, never
   // to the case literal (runtime throws on it too).
   // ---------------------------------------------------------------------

--- a/packages/browser/src/contract/types.ts
+++ b/packages/browser/src/contract/types.ts
@@ -338,8 +338,10 @@ export function defineBrowserCase<
  * `PageType` defaults to `InstrumentedPage`. {@link browserCase} infers it from
  * the case's own `client` or from the enclosing contract's `.with(...)` client;
  * a client passed as the contract SPEC's `client` does NOT reach it (see
- * {@link browserCase} for why, and for the two supported alternatives). Pass the
- * parameter explicitly when annotating a case body for a non-default page.
+ * {@link browserCase} for why). The supported alternative there is `.with(...)`
+ * — a case-level client does NOT substitute, since it cannot widen the contract
+ * the case is placed in. Pass the parameter explicitly when annotating a case
+ * body for a non-default page.
  */
 export type BrowserCaseBody<
   N,

--- a/packages/browser/src/contract/types.ts
+++ b/packages/browser/src/contract/types.ts
@@ -300,6 +300,19 @@ export interface BrowserContractCase<
  * case's own const site so `steps[].action` / `verify` are checked against the
  * declared logical input instead of drifting from the `needs` schema (mirrors
  * `defineHttpCase` / `defineGraphqlCase`).
+ *
+ * @deprecated Use {@link browserCase} — same drift guard with zero explicit
+ * generics. Before:
+ * `defineBrowserCase<{ email: string }>({ needs: Schema, steps: [...] })`;
+ * after: `browserCase(Schema)({ steps: [...] })`.
+ *
+ * One shape still needs this factory: a case declared OUTSIDE its contract, with
+ * no per-case `client`, whose `action` must reach a non-default page capability
+ * (e.g. `page.extension` on an `ExtensionPage`). `browserCase` infers `PageType`
+ * from a value — the case's own `client`, or the enclosing contract — and a
+ * standalone client-less case supplies neither, while `defineBrowserCase<Input,
+ * ExtensionPage>` can still spell it out. Declaring the case inline in its
+ * contract (the documented pattern) infers it and needs nothing explicit.
  */
 export function defineBrowserCase<
   Input = void,
@@ -308,6 +321,156 @@ export function defineBrowserCase<
   c: BrowserContractCase<Input, PageType>,
 ): BrowserContractCase<Input, PageType> {
   return c;
+}
+
+/**
+ * Case body for {@link browserCase} — `BrowserContractCase` WITHOUT `needs`;
+ * the factory owns that field.
+ *
+ * `needs` is pinned to `never` rather than merely omitted: TypeScript runs no
+ * excess-property check against a type parameter's CONSTRAINT, so a bare
+ * `Omit<...>` would silently absorb a stray `needs` key into the inferred case
+ * type and leave two competing declarations of the same schema. The `never`
+ * makes writing a schema there a compile error at the offending property. An
+ * explicit `needs: undefined` still passes — `exactOptionalPropertyTypes` is
+ * off in this repo and it declares nothing anyway.
+ */
+export type BrowserCaseBody<
+  N,
+  PageType extends InstrumentedPage = InstrumentedPage,
+> = Omit<BrowserContractCase<N, PageType>, "needs"> & { needs?: never };
+
+/**
+ * Curried browser case factory — {@link defineBrowserCase}'s needs-drift guard
+ * with zero explicit generics. Prefer this.
+ *
+ * **Why curried.** TypeScript can't correlate sibling fields of one object
+ * literal, so `needs: SchemaLike<X>` never types the `steps[].action` written
+ * beside it — a factory has to capture `Input` first. But TS also has no PARTIAL
+ * type-argument inference: the moment an author writes
+ * `defineBrowserCase<Input>(...)`, every remaining type parameter falls back to
+ * its default. Splitting the call in two leaves nothing to default — `N` is
+ * inferred from the schema VALUE in the first call, `C` from the case literal in
+ * the second (contextually typed by `BrowserCaseBody<N, P>`, which is what still
+ * threads `N` into `action` / `verify`).
+ *
+ * What that buys over `defineBrowserCase`:
+ * - **No explicit generics.** The schema is written once, as a value, and the
+ *   whole case is checked against it.
+ * - **Drift guard on the journey.** `steps[].action` and `verify` take the
+ *   case's logical input, so destructuring a key that isn't on `N` is a compile
+ *   error instead of an `undefined` typed into a form field at replay time.
+ * - **One declaration site.** A `needs` SCHEMA inside the case literal is both a
+ *   compile error (see {@link BrowserCaseBody}) and a runtime `Error`. The one
+ *   tolerated form is an explicit `needs: undefined`, which declares nothing:
+ *   `exactOptionalPropertyTypes` is off here, so `needs?: never` admits it, and
+ *   every runtime reader already treats undefined as "no needs" — rejecting it
+ *   would make the type layer and the runtime promise different things.
+ *
+ * **How `PageType` survives.** It is the one type parameter with no schema to
+ * infer from, so it rides two value-shaped routes instead, and the return type
+ * restates `steps` as `BrowserStep<N, P>[]` for exactly that reason — a `P` that
+ * appeared only in `C`'s constraint would be unreachable by inference:
+ * 1. the case's own `client` (hence the `& { client?: BrowserPageClient<P> }` on
+ *    the parameter — an inference site for a VALUE the author already writes), or
+ * 2. the enclosing contract: `contract.browser.with("x", { client: chrome })`
+ *    fixes the factory's page type, which contextually types this call's return
+ *    and pins `P` before the `action` bodies are checked.
+ *
+ * Neither route applies to a standalone, client-less case, which falls back to
+ * `InstrumentedPage`; annotating an `action`'s `page` parameter more narrowly
+ * cannot recover it (parameter contravariance rejects it), so that one shape
+ * keeps using `defineBrowserCase<Input, PageType>`. Restating `steps` costs the
+ * step literals' types, which nothing consumes — core reads only `needs`.
+ *
+ * Runtime output is VALUE-IDENTICAL to the pre-migration shape — a case that
+ * declared `needs` inline — because the factory only spreads the schema back
+ * in. Migrating an existing case moves neither its projection nor its
+ * `canonicalHash`.
+ *
+ * @example
+ * ```ts
+ * import { contract } from "@glubean/sdk";
+ * import { browserCase } from "@glubean/browser";
+ * import { z } from "zod";
+ *
+ * const signIn = browserCase(z.object({ email: z.string(), password: z.string() }))({
+ *   description: "a returning user signs in",
+ *   entry: "/login",
+ *   steps: [
+ *     {
+ *       id: "submit",
+ *       intent: "fill the credentials and submit the form",
+ *       // `input` is { email: string; password: string } — inferred.
+ *       action: async (page, { email, password }) => {
+ *         await page.fill(page.byLabel("Email"), email);
+ *         await page.fill(page.byLabel("Password"), password);
+ *         await page.click(page.byRole("button", { name: "Sign in" }));
+ *       },
+ *     },
+ *   ],
+ *   expect: [{ id: "lands-on-dashboard", url: { path: "/dashboard" } }],
+ * });
+ *
+ * const journeys = contract.browser.with("app", { client });
+ * export const auth = journeys("auth.signIn", { cases: { signIn } });
+ * ```
+ *
+ * @param needs The case's logical input schema — declared here, exactly once.
+ *   Omit the argument entirely for a case with no logical input; that form
+ *   returns the case unchanged and still rejects a literal `needs`.
+ * @returns A function taking the case literal, returning it with `needs` attached.
+ */
+export function browserCase<N>(
+  needs: SchemaLike<N>,
+): <
+  const C extends BrowserCaseBody<N, PageType>,
+  PageType extends InstrumentedPage = InstrumentedPage,
+>(
+  c: C & { client?: BrowserPageClient<PageType> },
+  // `Omit<C, "needs">` before the intersection, never a bare `C & {...}`: a case
+  // written against the exported `BrowserCaseBody<X>` annotation carries the
+  // `needs?: never` guard INTO `C`, and intersecting that with the required
+  // `needs: SchemaLike<N>` collapses the property (and with it core's
+  // `InferCaseInput`, and with THAT the whole `.case()` I/O chain) to `never`.
+  // Dropping the guarded key first keeps every other property's literal type
+  // intact. `steps` is restated for the `PageType` inference route documented
+  // above.
+) => Omit<C, "needs" | "steps"> & {
+  needs: SchemaLike<N>;
+  steps: BrowserStep<N, PageType>[];
+};
+export function browserCase(): <
+  const C extends BrowserCaseBody<void, PageType>,
+  PageType extends InstrumentedPage = InstrumentedPage,
+>(
+  c: C & { client?: BrowserPageClient<PageType> },
+) => Omit<C, "steps"> & { steps: BrowserStep<void, PageType>[] };
+export function browserCase(needs?: SchemaLike<unknown>) {
+  // Keep JS consumers aligned with the type-level `needs?: never` — a literal
+  // `needs` SCHEMA is a hard error in BOTH forms, so it always has exactly one
+  // declaration site. The zero-arg form returns the case unchanged.
+  //
+  // The two overloads above are the checked authoring surface; this
+  // implementation is untyped glue (a concrete param type is not compatible
+  // with both of them).
+  return (c: any) => {
+    // Value check, NOT hasOwnProperty: `exactOptionalPropertyTypes` is off in
+    // this repo, so `needs?: never` accepts an explicit `needs: undefined` and
+    // the runtime must accept it too, or the two layers promise different
+    // things. Tolerating it is safe because every runtime reader treats
+    // undefined as "no needs declared" (core's §5.1 branches are falsy checks;
+    // the projection records `hasNeeds: c.needs !== undefined`). In the schema
+    // form the spread below overwrites the key anyway.
+    if (c.needs !== undefined) {
+      throw new Error(
+        "browserCase: do not declare `needs` inside the case literal — the factory " +
+          "owns that field. Declare it once as `browserCase(schema)({ ... })` and " +
+          "remove `needs` from the case object.",
+      );
+    }
+    return needs === undefined ? c : { ...c, needs };
+  };
 }
 
 // =============================================================================

--- a/packages/browser/src/contract/types.ts
+++ b/packages/browser/src/contract/types.ts
@@ -334,6 +334,12 @@ export function defineBrowserCase<
  * makes writing a schema there a compile error at the offending property. An
  * explicit `needs: undefined` still passes — `exactOptionalPropertyTypes` is
  * off in this repo and it declares nothing anyway.
+ *
+ * `PageType` defaults to `InstrumentedPage`. {@link browserCase} infers it from
+ * the case's own `client` or from the enclosing contract's `.with(...)` client;
+ * a client passed as the contract SPEC's `client` does NOT reach it (see
+ * {@link browserCase} for why, and for the two supported alternatives). Pass the
+ * parameter explicitly when annotating a case body for a non-default page.
  */
 export type BrowserCaseBody<
   N,
@@ -377,11 +383,29 @@ export type BrowserCaseBody<
  *    fixes the factory's page type, which contextually types this call's return
  *    and pins `P` before the `action` bodies are checked.
  *
- * Neither route applies to a standalone, client-less case, which falls back to
+ * Restating `steps` costs the step literals' types, which nothing consumes —
+ * core reads only `needs`.
+ *
+ * **Two shapes those routes do NOT cover** (both fall back to
  * `InstrumentedPage`; annotating an `action`'s `page` parameter more narrowly
- * cannot recover it (parameter contravariance rejects it), so that one shape
- * keeps using `defineBrowserCase<Input, PageType>`. Restating `steps` costs the
- * step literals' types, which nothing consumes — core reads only `needs`.
+ * cannot recover either, because parameter contravariance rejects it):
+ * - A standalone, client-less case. Give the case a `client`, declare it inline
+ *   in its contract, or keep `defineBrowserCase<Input, PageType>`.
+ * - A client supplied as the CONTRACT SPEC's `client` — `journeys("id", {
+ *   client: chrome, cases: { ... } })` — rather than on `.with(...)` or on the
+ *   case. This route is fully supported at runtime, but `BrowserContractFactory`
+ *   binds its page type when `.with(...)` is called, so by the time the spec
+ *   literal is checked the type is already fixed and the spec's own `client` has
+ *   no say. Making it an inference site requires a per-call type parameter on
+ *   the factory, and that DEMOTES the page type to an unresolved type variable
+ *   while `cases` is being contextually typed — which breaks route 2, the common
+ *   one (measured: both a per-call parameter and an overload pair regressed
+ *   `.with({ client })`). Until that is solved, pass the client to `.with(...)`.
+ *   The case route does NOT substitute here: a case-level client types the case
+ *   itself, but cannot widen the contract it is placed in — that contract's
+ *   `cases` constraint wants an action accepting its own, wider page.
+ *   `types.test-d.ts` pins all three behaviors so a future change cannot land
+ *   silently.
  *
  * Runtime output is VALUE-IDENTICAL to the pre-migration shape — a case that
  * declared `needs` inline — because the factory only spreads the schema back

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -80,7 +80,7 @@ const browserPlugin: PluginManifest = definePlugin({
 
 export default browserPlugin;
 
-// Contract authoring surface (types, defineBrowserCase, matchers, adapter).
+// Contract authoring surface (types, browserCase, matchers, adapter).
 export * from "./contract/index.js";
 export type {
   ActionOptions,

--- a/packages/browser/tsconfig.build.json
+++ b/packages/browser/tsconfig.build.json
@@ -8,5 +8,5 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
 }

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -31,7 +31,7 @@ await installPlugin(graphqlPlugin);
 
 ```ts
 import { contract, configure } from "@glubean/sdk";
-import { graphql, gql } from "@glubean/graphql";
+import { graphql, gql, graphqlCase } from "@glubean/graphql";
 import { z } from "zod";
 
 const { api } = configure({
@@ -47,40 +47,47 @@ const userContracts = contract.graphql.with("user-api", {
   client: api,
 });
 
+// A case's logical input is declared ONCE — as the schema argument to
+// `graphqlCase`. TypeScript then types `variables` / `headers` from it, so a
+// key that isn't on the schema is a compile error instead of an `undefined`
+// silently sent on the wire.
+const happy = graphqlCase(z.object({ id: z.string() }))({
+  description: "existing user returns name + email",
+  query: gql`
+    query GetUser($id: ID!) {
+      user(id: $id) { id name email }
+    }
+  `,
+  // `id` is `string` — inferred from the schema above, never annotated.
+  variables: ({ id }) => ({ id }),
+  expect: {
+    httpStatus: 200,
+    data: { user: { id: "u_123", name: "Alice" } },
+    errors: "absent",
+  },
+});
+
+// A case with no logical input uses the zero-argument form.
+const unauth = graphqlCase()({
+  description: "missing token yields 401",
+  query: `query Me { me { id } }`,
+  headers: {},
+  expect: { httpStatus: 401, errors: "any" },
+});
+
+const forbidden = graphqlCase()({
+  description: "server returns FORBIDDEN on scope mismatch",
+  query: `query AdminOnly { admin { key } }`,
+  expect: {
+    httpStatus: 200,
+    errors: [{ extensions: { code: "FORBIDDEN" } }],
+  },
+});
+
 export const getUser = userContracts("get-user", {
   endpoint: "/graphql",
   description: "Fetch a user by id",
-  cases: {
-    happy: {
-      description: "existing user returns name + email",
-      needs: z.object({ id: z.string() }),
-      query: gql`
-        query GetUser($id: ID!) {
-          user(id: $id) { id name email }
-        }
-      `,
-      variables: ({ id }) => ({ id }),
-      expect: {
-        httpStatus: 200,
-        data: { user: { id: "u_123", name: "Alice" } },
-        errors: "absent",
-      },
-    },
-    unauth: {
-      description: "missing token yields 401",
-      query: `query Me { me { id } }`,
-      headers: {},
-      expect: { httpStatus: 401, errors: "any" },
-    },
-    forbidden: {
-      description: "server returns FORBIDDEN on scope mismatch",
-      query: `query AdminOnly { admin { key } }`,
-      expect: {
-        httpStatus: 200,
-        errors: [{ extensions: { code: "FORBIDDEN" } }],
-      },
-    },
-  },
+  cases: { happy, unauth, forbidden },
 });
 ```
 

--- a/packages/graphql/src/contract/graphql-case.test.ts
+++ b/packages/graphql/src/contract/graphql-case.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Runtime behavior of the `graphqlCase` curried case factory.
+ *
+ * The factory is a TYPING device (it correlates `needs` with the function-valued
+ * action fields TypeScript can't correlate across sibling literal fields), so its
+ * runtime job is deliberately tiny: attach the schema, and keep the schema's
+ * single declaration site enforceable for JavaScript consumers too.
+ *
+ * Compile-time behavior (drift guard, preserved literal typing) lives in
+ * `./types.test-d.ts`.
+ */
+
+import { test, expect } from "vitest";
+import { graphqlCase } from "../index.js";
+import type { SchemaLike } from "@glubean/sdk";
+
+/** Minimal SchemaLike — identity parse is enough; nothing here validates. */
+const needsSchema: SchemaLike<{ userId: string }> = {
+  safeParse: (d: unknown) => ({ success: true as const, data: d as { userId: string } }),
+} as SchemaLike<{ userId: string }>;
+
+test("graphqlCase(schema)(case) returns a new object carrying the schema as `needs`", () => {
+  const variables = ({ userId }: { userId: string }) => ({ id: userId });
+  const spec = {
+    description: "fetches a user",
+    query: "query User($id: ID!) { user(id: $id) { id } }",
+    variables,
+    expect: { httpStatus: 200 },
+  } as const;
+
+  const built = graphqlCase(needsSchema)(spec);
+
+  // New object — the input literal is never mutated.
+  expect(built).not.toBe(spec);
+  // Every authored field survives, by reference for the function-valued ones.
+  expect(built.description).toBe("fetches a user");
+  expect(built.query).toBe("query User($id: ID!) { user(id: $id) { id } }");
+  expect(built.variables).toBe(variables);
+  expect(built.expect).toEqual({ httpStatus: 200 });
+  // ...plus the schema the factory owns, by reference.
+  expect(built.needs).toBe(needsSchema);
+
+  // Value-identical to writing `needs` inside the case literal — migrating an
+  // existing case must not move its projection or canonicalHash.
+  expect({ ...built }).toEqual({ ...spec, needs: needsSchema });
+});
+
+test("graphqlCase()(case) returns the case unchanged", () => {
+  const spec = {
+    description: "health probe",
+    query: "query Health { health }",
+  } as const;
+
+  const built = graphqlCase()(spec);
+
+  expect(built.description).toBe("health probe");
+  expect(built.query).toBe("query Health { health }");
+  expect(Object.prototype.hasOwnProperty.call(built, "needs")).toBe(false);
+  expect({ ...built }).toEqual({ ...spec });
+});
+
+// A literal `needs` is a compile error (`GraphqlCaseBody` pins the field to
+// `never`); these casts reproduce what an untyped JavaScript consumer can still
+// write, and assert the runtime refuses it in BOTH forms.
+type UntypedCaseFactory = (c: Record<string, unknown>) => unknown;
+
+test("literal `needs` in the case throws — schema form", () => {
+  const build = graphqlCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs twice",
+      query: "q",
+      needs: needsSchema,
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+test("literal `needs` in the case throws — zero-arg form", () => {
+  const build = graphqlCase() as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs without a factory schema",
+      query: "q",
+      needs: needsSchema,
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+// An explicit `needs: undefined` declares nothing, and the type layer admits it
+// (`needs?: never` + no `exactOptionalPropertyTypes`). The runtime must agree —
+// every reader of the field treats undefined as "no needs declared".
+test("`needs: undefined` is tolerated — schema form overwrites it", () => {
+  const built = graphqlCase(needsSchema)({
+    description: "explicit undefined",
+    query: "q",
+    needs: undefined,
+  });
+
+  expect(built.needs).toBe(needsSchema);
+});
+
+test("`needs: undefined` is tolerated — zero-arg form leaves it undefined", () => {
+  const built = graphqlCase()({
+    description: "explicit undefined, no factory schema",
+    query: "q",
+    needs: undefined,
+  });
+
+  expect(built.needs).toBeUndefined();
+});
+
+test("the throw names the one supported declaration site", () => {
+  const build = graphqlCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({ description: "x", query: "q", needs: needsSchema }),
+  ).toThrow(/graphqlCase\(schema\)\(\{ \.\.\. \}\)/);
+});

--- a/packages/graphql/src/contract/index.ts
+++ b/packages/graphql/src/contract/index.ts
@@ -13,8 +13,9 @@
 export { graphqlAdapter } from "./adapter.js";
 export { createGraphqlFactory, createGraphqlRoot } from "./factory.js";
 export { graphqlMatchers } from "./matchers.js";
-export { defineGraphqlCase } from "./types.js";
+export { defineGraphqlCase, graphqlCase } from "./types.js";
 export type {
+  GraphqlCaseBody,
   GraphqlContractCase,
   GraphqlContractDefaults,
   GraphqlContractExample,

--- a/packages/graphql/src/contract/types.test-d.ts
+++ b/packages/graphql/src/contract/types.test-d.ts
@@ -2,11 +2,23 @@
  * Type-level tests for GraphQL contract case factories.
  *
  * These are compile-only checks. They prove `defineGraphqlCase<Needs>` locks
- * the logical input shape across `needs`, `variables`, and `headers`.
+ * the logical input shape across `needs`, `variables`, and `headers`, and that
+ * the curried `graphqlCase(schema)(case)` does the same with NOTHING defaulted:
+ * `N` is inferred from the schema VALUE (first call) and `C` from the case
+ * literal (second call), so the case keeps its literal type — which is what
+ * `InferGraphqlResponse` / `InferGraphqlVariables` read.
  */
 
-import { defineGraphqlCase } from "../index.js";
+import { contract } from "@glubean/sdk";
 import type { SchemaLike } from "@glubean/sdk";
+import { defineGraphqlCase, graphqlCase } from "../index.js";
+import type {
+  GraphqlCaseBody,
+  GraphqlContractCase,
+  InferGraphqlResponse,
+  InferGraphqlVariables,
+} from "../index.js";
+import type { GraphQLClient } from "../index.js";
 
 function s<T>(): SchemaLike<T> {
   return {} as SchemaLike<T>;
@@ -40,4 +52,215 @@ function s<T>(): SchemaLike<T> {
     headers: ({ missing }: { missing: string }) => ({ authorization: missing }),
   });
   void _headersDrift;
+}
+
+// =============================================================================
+// graphqlCase(schema)(case) — the curried factory.
+// =============================================================================
+
+declare const client: GraphQLClient;
+const api = contract.graphql.with("api", { client });
+
+{
+  // ---------------------------------------------------------------------
+  // 1. Positive contextual typing: the action-field param IS the schema's
+  // output type — inferred, never annotated.
+  // ---------------------------------------------------------------------
+  const typedInput = graphqlCase(s<{ token: string; userId: string }>())({
+    description: "fetch user",
+    query: "query User($id: ID!) { user(id: $id) { id } }",
+    variables: (input) => {
+      // Proves `input` is `{token, userId}` and NOT implicitly `any` (which
+      // would make the drift assertions below vacuous). `any` here is the real
+      // hazard: `variables?: Vars | ((input) => Vars)` collapses to `any` if
+      // the body type's `Vars` slot is `any`, silently dropping the guard.
+      const userId: string = input.userId;
+      return { id: userId };
+    },
+    headers: ({ token }) => ({ authorization: `Bearer ${token}` }),
+    expect: {
+      httpStatus: 200,
+      errors: "absent",
+      schema: s<{ user: { id: string } }>(),
+    },
+    verify: async (_ctx, res) => {
+      // `res` is GraphqlCaseResult<any> — see the factory's JSDoc for why it is
+      // NOT narrowed here (GraphQL's `Res` is contract-level).
+      void res.data;
+      const status: number = res.httpStatus;
+      void status;
+    },
+  });
+  void typedInput;
+
+  // ---------------------------------------------------------------------
+  // 2. Drift guard: a key that is not on the schema is a compile error on
+  // every action field.
+  // ---------------------------------------------------------------------
+  const _driftVariables = graphqlCase(s<{ userId: string }>())({
+    description: "drift variables",
+    query: "q",
+    // @ts-expect-error -- `wrongKey` is not on Needs `{userId: string}`.
+    variables: ({ wrongKey }) => ({ id: wrongKey }),
+  });
+  void _driftVariables;
+
+  const _driftHeaders = graphqlCase(s<{ token: string }>())({
+    description: "drift headers",
+    query: "q",
+    // @ts-expect-error -- `missing` is not on Needs `{token: string}`.
+    headers: ({ missing }) => ({ authorization: missing }),
+  });
+  void _driftHeaders;
+
+  // ---------------------------------------------------------------------
+  // 3. Typed response preserved: `expect.schema` survives into the case's
+  // type, so `InferGraphqlResponse` resolves it — the motivation for the
+  // curried shape.
+  // ---------------------------------------------------------------------
+  type CurriedResponse = InferGraphqlResponse<typeof typedInput>;
+  const _responseIsTyped: CurriedResponse = { user: { id: "u1" } };
+  // @ts-expect-error -- response is `{user: {id: string}}`, so a wrong shape fails.
+  const _responseNotAny: CurriedResponse = { wrong: 1 };
+  // `unknown` is only assignable TO `unknown` — false here proves it resolved.
+  const _responseNotUnknown: [unknown] extends [CurriedResponse] ? true : false = false;
+  void _responseIsTyped;
+  void _responseNotAny;
+  void _responseNotUnknown;
+
+  // Variables resolve from the literal too. The second assertion rules out
+  // BOTH `unknown` and `any` (`[unknown] extends [any]` is also true).
+  type CurriedVariables = InferGraphqlVariables<typeof typedInput>;
+  const _variablesTyped: CurriedVariables = { id: "u1" };
+  const _variablesResolved: [unknown] extends [CurriedVariables] ? true : false = false;
+  void _variablesTyped;
+  void _variablesResolved;
+
+  // Contrast — the same case through defineGraphqlCase degrades to `unknown`,
+  // because its nominal `GraphqlContractCase<Vars, Res, Needs>` return pins
+  // `Res` to the parameter's DEFAULT unless the author also spells it out.
+  const nominalCase = defineGraphqlCase<{ userId: string }>({
+    description: "fetch user",
+    needs: s<{ userId: string }>(),
+    query: "q",
+    variables: ({ userId }) => ({ id: userId }),
+    expect: { schema: s<{ user: { id: string } }>() },
+  });
+  const _nominalIsUnknown: [unknown] extends [
+    InferGraphqlResponse<typeof nominalCase>,
+  ]
+    ? true
+    : false = true;
+  void _nominalIsUnknown;
+
+  // ---------------------------------------------------------------------
+  // 4. Single declaration site: `needs` belongs to the factory call, never
+  // to the case literal (runtime throws on it too).
+  // ---------------------------------------------------------------------
+  const _doubleDeclared = graphqlCase(s<{ userId: string }>())({
+    description: "declares needs twice",
+    query: "q",
+    // @ts-expect-error -- `needs` is owned by the factory; GraphqlCaseBody pins
+    // the field to `never` so writing it here cannot compile.
+    needs: s<{ userId: string }>(),
+  });
+  void _doubleDeclared;
+
+  // ...but an explicit `needs: undefined` DECLARES NOTHING and compiles:
+  // `exactOptionalPropertyTypes` is off, so `needs?: never` admits undefined.
+  // The runtime tolerates it for exactly this reason (see graphql-case.test.ts)
+  // — the two layers must promise the same thing.
+  const _explicitUndefined = graphqlCase(s<{ userId: string }>())({
+    description: "explicit undefined declares nothing",
+    query: "q",
+    needs: undefined,
+    variables: ({ userId }) => ({ id: userId }),
+  });
+  void _explicitUndefined;
+
+  // ---------------------------------------------------------------------
+  // 5. Zero-arg form for cases with no logical input.
+  // ---------------------------------------------------------------------
+  const noNeedsCase = graphqlCase()({
+    description: "no logical input",
+    query: "query Health { health }",
+  });
+  const _assignableAsCase: GraphqlContractCase = noNeedsCase;
+  void _assignableAsCase;
+
+  // Still one declaration site in the zero-arg form.
+  const _zeroArgDoubleDeclared = graphqlCase()({
+    description: "declares needs without a factory schema",
+    query: "q",
+    // @ts-expect-error -- `needs` is owned by the factory in BOTH forms.
+    needs: s<{ userId: string }>(),
+  });
+  void _zeroArgDoubleDeclared;
+
+  // ---------------------------------------------------------------------
+  // 6. The returned case is accepted by the real contract factory, and the
+  // resulting `.case()` ref carries the per-case Needs.
+  // ---------------------------------------------------------------------
+  const users = api("user.fetch", {
+    cases: { ok: typedInput, health: noNeedsCase },
+  });
+
+  const okRef = users.case("ok");
+  type OkInput = typeof okRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _okInput: OkInput = { token: "t", userId: "u" };
+  // @ts-expect-error -- proves the ref input is Needs, not `any`.
+  const _okInputNotAny: OkInput = { completelyWrongField: "x" };
+  void _okInput;
+  void _okInputNotAny;
+}
+
+// =============================================================================
+// Regression: a case body written against the EXPORTED `GraphqlCaseBody<N>`
+// annotation must survive the factory.
+//
+// `GraphqlCaseBody` carries the `needs?: never` single-declaration guard, so a
+// bare `C & { needs: SchemaLike<N> }` return type intersects `never` with a
+// required property and collapses `needs` — taking core's `InferCaseInput` (and
+// with it the whole `.case()` I/O chain) down to `never`. The return type drops
+// the guarded key first (`Omit<C, "needs"> & ...`), which is what these assert.
+// =============================================================================
+
+{
+  type Needs = { email: string };
+
+  const preAnnotated: GraphqlCaseBody<Needs> = {
+    description: "pre-annotated case body",
+    query: "mutation Signup($email: String!) { signup(email: $email) { id } }",
+    variables: ({ email }) => ({ email }),
+  };
+
+  const built = graphqlCase(s<Needs>())(preAnnotated);
+
+  // `needs` must be the schema, NOT `never`.
+  const _needsUsable: SchemaLike<Needs> = built.needs;
+  const _needsNotNever: [(typeof built)["needs"]] extends [never] ? true : false = false;
+  // Other fields stay reachable (a collapsed intersection makes the whole
+  // object unusable, not just its `needs`).
+  const _descReachable: string = built.description;
+  void _needsUsable;
+  void _needsNotNever;
+  void _descReachable;
+
+  // The whole `.case()` I/O chain still works off the built case, and the ref's
+  // input is EXACTLY Needs — asserted both ways, since a one-way `extends` also
+  // holds for `never`.
+  const preContract = api("user.signup", { cases: { ok: built } });
+  const preRef = preContract.case("ok");
+  type PreRefInput = typeof preRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _inputIsExactlyNeeds: [PreRefInput] extends [Needs]
+    ? [Needs] extends [PreRefInput]
+      ? true
+      : false
+    : false = true;
+  void _inputIsExactlyNeeds;
+
+  // NOTE the deliberate non-assertion: annotating the body as
+  // `GraphqlCaseBody<Needs>` WIDENS the literal, so `expect.schema` presence is
+  // erased and `InferGraphqlResponse` degrades on this path. That is the cost of
+  // pre-annotating, not a regression — the inline-literal path keeps it.
 }

--- a/packages/graphql/src/contract/types.test-d.ts
+++ b/packages/graphql/src/contract/types.test-d.ts
@@ -154,6 +154,45 @@ const api = contract.graphql.with("api", { client });
   void _nominalIsUnknown;
 
   // ---------------------------------------------------------------------
+  // 3b. The static branch must REJECT function values. `variables?: Vars |
+  // ((input) => Vars)` is a union, so a permissive static slot (a bare
+  // `object`, say) would accept every function — TS treats functions as
+  // objects — and silently re-admit three drift-bypassing forms, each
+  // corrupting the operation at runtime. `Vars` is `Record<string, unknown>`,
+  // which has no such leak; these pin that (gRPC needs an explicit guard for
+  // the same three forms because its `Req` slot must also admit protobuf
+  // INTERFACES, which a record rejects — see `GrpcRequestMessage`).
+  // ---------------------------------------------------------------------
+
+  // (i) A pre-declared builder whose ANNOTATED parameter drifts from the schema.
+  const driftingBuilder = (i: { wrongKey: string }) => ({ id: i.wrongKey });
+  const _staticDrift = graphqlCase(s<{ userId: string }>())({
+    description: "pre-declared builder with a drifting annotated param",
+    query: "q",
+    // @ts-expect-error -- neither branch may accept it.
+    variables: driftingBuilder,
+  });
+  void _staticDrift;
+
+  // (ii) An `async` builder — its Promise is not a variables object.
+  const _asyncBuilder = graphqlCase(s<{ userId: string }>())({
+    description: "async variables builder",
+    query: "q",
+    // @ts-expect-error -- a Promise is not a variables record.
+    variables: async ({ userId }) => ({ id: userId }),
+  });
+  void _asyncBuilder;
+
+  // (iii) A builder returning a PRIMITIVE.
+  const _primitiveBuilder = graphqlCase(s<{ userId: string }>())({
+    description: "variables builder returning a primitive",
+    query: "q",
+    // @ts-expect-error -- a string is not a variables record.
+    variables: ({ userId }) => userId,
+  });
+  void _primitiveBuilder;
+
+  // ---------------------------------------------------------------------
   // 4. Single declaration site: `needs` belongs to the factory call, never
   // to the case literal (runtime throws on it too).
   // ---------------------------------------------------------------------

--- a/packages/graphql/src/contract/types.ts
+++ b/packages/graphql/src/contract/types.ts
@@ -247,6 +247,12 @@ export interface GraphqlContractCase<
  * Captures `Needs` at the case's own const site so function-valued
  * `variables` and `headers` fields are checked against the declared logical
  * input instead of drifting independently from the `needs` schema.
+ *
+ * @deprecated Use {@link graphqlCase} — same drift guard with zero explicit
+ * generics, and it keeps the case's literal type (so `InferGraphqlResponse` /
+ * `InferGraphqlVariables` resolve instead of degrading). Before:
+ * `defineGraphqlCase<{ userId: string }>({ needs: Schema, variables: ({ userId }) => ({ id: userId }) })`;
+ * after: `graphqlCase(Schema)({ variables: ({ userId }) => ({ id: userId }) })`.
  */
 export function defineGraphqlCase<
   Needs = void,
@@ -256,6 +262,147 @@ export function defineGraphqlCase<
   c: GraphqlContractCase<Vars, Res, Needs>,
 ): GraphqlContractCase<Vars, Res, Needs> {
   return c;
+}
+
+/**
+ * Case body for {@link graphqlCase} — `GraphqlContractCase` WITHOUT `needs`;
+ * the factory owns that field.
+ *
+ * `needs` is pinned to `never` rather than merely omitted: TypeScript runs no
+ * excess-property check against a type parameter's CONSTRAINT, so a bare
+ * `Omit<...>` would silently absorb a stray `needs` key into the inferred case
+ * type and leave two competing declarations of the same schema. The `never`
+ * makes writing a schema there a compile error at the offending property. An
+ * explicit `needs: undefined` still passes — `exactOptionalPropertyTypes` is
+ * off in this repo and it declares nothing anyway.
+ *
+ * The `Vars` slot is the concrete `Record<string, unknown>` default, NOT `any`:
+ * `variables?: Vars | ((input: Needs) => Vars)` is a union whose static branch
+ * would SWALLOW the function branch if it were `any` (`any | F` collapses to
+ * `any`), and the drift guard would silently evaporate — the parameter of
+ * `variables: ({ userId }) => ...` would go implicitly `any`. It is also the
+ * shape `GraphqlContractSpec` already requires (`Vars extends Record<string,
+ * unknown>`), so a variables value that this rejects would be rejected at the
+ * contract call anyway — here it fails at the offending case instead.
+ *
+ * The `Res` slot IS `any` (same as HTTP's `HttpCaseBody`): it only reaches
+ * `expect` and `verify`, never a union with a function, so it cannot swallow
+ * anything.
+ */
+export type GraphqlCaseBody<N> = Omit<
+  GraphqlContractCase<Record<string, unknown>, any, N>,
+  "needs"
+> & { needs?: never };
+
+/**
+ * Curried GraphQL case factory — {@link defineGraphqlCase}'s needs-drift guard
+ * with zero explicit generics, and without its type-erasing trade. Prefer this.
+ *
+ * **Why curried.** TypeScript can't correlate sibling fields of one object
+ * literal, so `needs: SchemaLike<X>` never types the `variables: (input) => ...`
+ * written beside it — a factory has to capture `Needs` first. But TS also has
+ * no PARTIAL type-argument inference: the moment an author writes
+ * `defineGraphqlCase<Needs>(...)`, every remaining type parameter falls back to
+ * its default and the case widens to the nominal `GraphqlContractCase<Vars, Res,
+ * Needs>`. Splitting the call in two leaves nothing to default — `N` is inferred
+ * from the schema VALUE in the first call, `C` from the case literal in the
+ * second (contextually typed by `GraphqlCaseBody<N>`, which is what still
+ * threads `N` into the action fields).
+ *
+ * What that buys over `defineGraphqlCase`:
+ * - **No explicit generics.** The schema is written once, as a value, and the
+ *   whole case is checked against it.
+ * - **Drift guard on both action fields** — `variables` / `headers` take
+ *   `(input: N) => ...`, so destructuring a key that isn't on `N` is a compile
+ *   error instead of a silently `undefined` field in the outgoing operation.
+ * - **The case keeps its LITERAL type**, so `InferGraphqlResponse` /
+ *   `InferGraphqlVariables` resolve the real `expect.schema` / `variables`
+ *   types; the nominal return of `defineGraphqlCase` erases both to their
+ *   defaults unless the author also spells out `Vars` and `Res` by hand.
+ * - **One declaration site.** A `needs` SCHEMA inside the case literal is both a
+ *   compile error (see {@link GraphqlCaseBody}) and a runtime `Error`. The one
+ *   tolerated form is an explicit `needs: undefined`, which declares nothing:
+ *   `exactOptionalPropertyTypes` is off here, so `needs?: never` admits it, and
+ *   every runtime reader already treats undefined as "no needs" — rejecting it
+ *   would make the type layer and the runtime promise different things.
+ *
+ * Runtime output is VALUE-IDENTICAL to the pre-migration shape — a case that
+ * declared `needs` inline — because the factory only spreads the schema back
+ * in. Migrating an existing case moves neither its projection nor its
+ * `canonicalHash`.
+ *
+ * `verify(ctx, res)`'s `res` is `GraphqlCaseResult<any>`, not inferred from
+ * `expect.schema` — that would need a second inference pass over the same
+ * literal. Do NOT annotate the parameter with a concrete result type: GraphQL's
+ * `Res` is CONTRACT-level (`GraphqlContractSpec<Vars, Res, Cases>`) and infers
+ * `unknown` when the spec declares no `responseSchema`, so a narrowed `verify`
+ * parameter makes the case unassignable to the contract's `cases` (a
+ * pre-existing constraint — `defineGraphqlCase<Needs, Vars, Res>` with an
+ * explicit `Res` hits the same wall). Narrow `res.data` inside the body instead;
+ * the schema still validates the response at runtime.
+ *
+ * @example
+ * ```ts
+ * import { contract } from "@glubean/sdk";
+ * import { graphqlCase } from "@glubean/graphql";
+ * import { z } from "zod";
+ *
+ * const fetchUser = graphqlCase(z.object({ userId: z.string(), token: z.string() }))({
+ *   description: "fetches a user by id",
+ *   query: "query User($id: ID!) { user(id: $id) { id name } }",
+ *   // `input` is { userId: string; token: string } — inferred, never annotated.
+ *   variables: ({ userId }) => ({ id: userId }),
+ *   headers: ({ token }) => ({ authorization: `Bearer ${token}` }),
+ *   expect: { schema: z.object({ user: z.object({ id: z.string() }) }) },
+ * });
+ *
+ * const api = contract.graphql.with("users", { client });
+ * export const users = api("user.fetch", { cases: { fetchUser } });
+ * ```
+ *
+ * @param needs The case's logical input schema — declared here, exactly once.
+ *   Omit the argument entirely for a case with no logical input; that form
+ *   returns the case unchanged and still rejects a literal `needs`.
+ * @returns A function taking the case literal, returning it with `needs` attached.
+ */
+export function graphqlCase<N>(
+  needs: SchemaLike<N>,
+): <const C extends GraphqlCaseBody<N>>(
+  c: C,
+  // `Omit<C, "needs">` before the intersection, never a bare `C & {...}`: a case
+  // written against the exported `GraphqlCaseBody<X>` annotation carries the
+  // `needs?: never` guard INTO `C`, and intersecting that with the required
+  // `needs: SchemaLike<N>` collapses the property (and with it core's
+  // `InferCaseInput`, and with THAT the whole `.case()` I/O chain) to `never`.
+  // Dropping the guarded key first keeps every other property's literal type
+  // intact.
+) => Omit<C, "needs"> & { needs: SchemaLike<N> };
+export function graphqlCase(): <const C extends GraphqlCaseBody<void>>(c: C) => C;
+export function graphqlCase(needs?: SchemaLike<unknown>) {
+  // Keep JS consumers aligned with the type-level `needs?: never` — a literal
+  // `needs` SCHEMA is a hard error in BOTH forms, so it always has exactly one
+  // declaration site. The zero-arg form returns the case unchanged.
+  //
+  // The two overloads above are the checked authoring surface; this
+  // implementation is untyped glue (a concrete param type is not compatible
+  // with both of them).
+  return (c: any) => {
+    // Value check, NOT hasOwnProperty: `exactOptionalPropertyTypes` is off in
+    // this repo, so `needs?: never` accepts an explicit `needs: undefined` and
+    // the runtime must accept it too, or the two layers promise different
+    // things. Tolerating it is safe because every runtime reader treats
+    // undefined as "no needs declared" (core's §5.1 branches are falsy checks;
+    // the projection records `hasNeeds: c.needs !== undefined`). In the schema
+    // form the spread below overwrites the key anyway.
+    if (c.needs !== undefined) {
+      throw new Error(
+        "graphqlCase: do not declare `needs` inside the case literal — the factory " +
+          "owns that field. Declare it once as `graphqlCase(schema)({ ... })` and " +
+          "remove `needs` from the case object.",
+      );
+    }
+    return needs === undefined ? c : { ...c, needs };
+  };
 }
 
 // =============================================================================

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -536,9 +536,11 @@ export {
   createGraphqlFactory,
   createGraphqlRoot,
   defineGraphqlCase,
+  graphqlCase,
   graphqlMatchers,
 } from "./contract/index.js";
 export type {
+  GraphqlCaseBody,
   GraphqlContractCase,
   GraphqlContractDefaults,
   GraphqlContractExample,

--- a/packages/grpc/README.md
+++ b/packages/grpc/README.md
@@ -31,7 +31,7 @@ await installPlugin(grpcPlugin);
 
 ```ts
 import { contract, configure } from "@glubean/sdk";
-import { grpc } from "@glubean/grpc";
+import { grpc, grpcCase } from "@glubean/grpc";
 import { z } from "zod";
 
 const { payment } = configure({
@@ -49,27 +49,33 @@ const paymentContracts = contract.grpc.with("payment-api", {
   client: payment,
 });
 
+// A case's logical input is declared ONCE — as the schema argument to
+// `grpcCase`. TypeScript then types `request` / `metadata` from it, so a key
+// that isn't on the schema is a compile error instead of an `undefined`
+// silently sent in the outgoing message.
+const happy = grpcCase(z.object({ orderId: z.string(), amount: z.number() }))({
+  description: "order with valid payment method completes successfully",
+  // `orderId` / `amount` are inferred from the schema above, never annotated.
+  request: ({ orderId, amount }) => ({ orderId, amount, currency: "USD" }),
+  expect: {
+    statusCode: 0, // OK
+    message: { status: "completed" },
+  },
+});
+
+// A case with no logical input uses the zero-argument form.
+const notFound = grpcCase()({
+  description: "unknown order id returns NOT_FOUND",
+  request: { orderId: "does-not-exist" },
+  expect: {
+    statusCode: 5, // NOT_FOUND
+  },
+});
+
 export const completePayment = paymentContracts("complete-payment", {
   target: "PaymentService/Complete",
   description: "Complete a pending payment by order id + amount",
-  cases: {
-    happy: {
-      description: "order with valid payment method completes successfully",
-      needs: z.object({ orderId: z.string(), amount: z.number() }),
-      request: ({ orderId, amount }) => ({ orderId, amount, currency: "USD" }),
-      expect: {
-        statusCode: 0, // OK
-        message: { status: "completed" },
-      },
-    },
-    notFound: {
-      description: "unknown order id returns NOT_FOUND",
-      request: { orderId: "does-not-exist" },
-      expect: {
-        statusCode: 5, // NOT_FOUND
-      },
-    },
-  },
+  cases: { happy, notFound },
 });
 ```
 

--- a/packages/grpc/src/contract/grpc-case.test.ts
+++ b/packages/grpc/src/contract/grpc-case.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Runtime behavior of the `grpcCase` curried case factory.
+ *
+ * The factory is a TYPING device (it correlates `needs` with the function-valued
+ * action fields TypeScript can't correlate across sibling literal fields), so its
+ * runtime job is deliberately tiny: attach the schema, and keep the schema's
+ * single declaration site enforceable for JavaScript consumers too.
+ *
+ * Compile-time behavior (drift guard, preserved literal typing) lives in
+ * `./types.test-d.ts`.
+ */
+
+import { test, expect } from "vitest";
+import { grpcCase } from "../index.js";
+import type { SchemaLike } from "@glubean/sdk";
+
+/** Minimal SchemaLike — identity parse is enough; nothing here validates. */
+const needsSchema: SchemaLike<{ userId: string }> = {
+  safeParse: (d: unknown) => ({ success: true as const, data: d as { userId: string } }),
+} as SchemaLike<{ userId: string }>;
+
+test("grpcCase(schema)(case) returns a new object carrying the schema as `needs`", () => {
+  const request = ({ userId }: { userId: string }) => ({ userId });
+  const spec = {
+    description: "fetches a user",
+    request,
+    expect: { statusCode: 0 },
+  } as const;
+
+  const built = grpcCase(needsSchema)(spec);
+
+  // New object — the input literal is never mutated.
+  expect(built).not.toBe(spec);
+  // Every authored field survives, by reference for the function-valued ones.
+  expect(built.description).toBe("fetches a user");
+  expect(built.request).toBe(request);
+  expect(built.expect).toEqual({ statusCode: 0 });
+  // ...plus the schema the factory owns, by reference.
+  expect(built.needs).toBe(needsSchema);
+
+  // Value-identical to writing `needs` inside the case literal — migrating an
+  // existing case must not move its projection or canonicalHash.
+  expect({ ...built }).toEqual({ ...spec, needs: needsSchema });
+});
+
+test("grpcCase()(case) returns the case unchanged", () => {
+  const spec = {
+    description: "health probe",
+    expect: { statusCode: 0 },
+  } as const;
+
+  const built = grpcCase()(spec);
+
+  expect(built.description).toBe("health probe");
+  expect(built.expect).toEqual({ statusCode: 0 });
+  expect(Object.prototype.hasOwnProperty.call(built, "needs")).toBe(false);
+  expect({ ...built }).toEqual({ ...spec });
+});
+
+// A literal `needs` is a compile error (`GrpcCaseBody` pins the field to
+// `never`); these casts reproduce what an untyped JavaScript consumer can still
+// write, and assert the runtime refuses it in BOTH forms.
+type UntypedCaseFactory = (c: Record<string, unknown>) => unknown;
+
+test("literal `needs` in the case throws — schema form", () => {
+  const build = grpcCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs twice",
+      needs: needsSchema,
+      expect: { statusCode: 0 },
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+test("literal `needs` in the case throws — zero-arg form", () => {
+  const build = grpcCase() as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({
+      description: "declares needs without a factory schema",
+      needs: needsSchema,
+      expect: { statusCode: 0 },
+    }),
+  ).toThrow(/do not declare `needs` inside the case literal/);
+});
+
+// An explicit `needs: undefined` declares nothing, and the type layer admits it
+// (`needs?: never` + no `exactOptionalPropertyTypes`). The runtime must agree —
+// every reader of the field treats undefined as "no needs declared".
+test("`needs: undefined` is tolerated — schema form overwrites it", () => {
+  const built = grpcCase(needsSchema)({
+    description: "explicit undefined",
+    needs: undefined,
+    expect: { statusCode: 0 },
+  });
+
+  expect(built.needs).toBe(needsSchema);
+});
+
+test("`needs: undefined` is tolerated — zero-arg form leaves it undefined", () => {
+  const built = grpcCase()({
+    description: "explicit undefined, no factory schema",
+    needs: undefined,
+    expect: { statusCode: 0 },
+  });
+
+  expect(built.needs).toBeUndefined();
+});
+
+test("the throw names the one supported declaration site", () => {
+  const build = grpcCase(needsSchema) as unknown as UntypedCaseFactory;
+
+  expect(() =>
+    build({ description: "x", needs: needsSchema, expect: { statusCode: 0 } }),
+  ).toThrow(/grpcCase\(schema\)\(\{ \.\.\. \}\)/);
+});

--- a/packages/grpc/src/contract/index.ts
+++ b/packages/grpc/src/contract/index.ts
@@ -29,6 +29,7 @@ export type {
   GrpcCaseResult,
   GrpcFlowCaseOutput,
   GrpcPayloadSchemas,
+  GrpcRequestMessage,
   GrpcSafeSchemas,
   InferGrpcRequest,
   InferGrpcResponse,

--- a/packages/grpc/src/contract/index.ts
+++ b/packages/grpc/src/contract/index.ts
@@ -14,8 +14,9 @@
 export { grpcAdapter } from "./adapter.js";
 export { createGrpcFactory, createGrpcRoot } from "./factory.js";
 export { grpcMatchers } from "./matchers.js";
-export { defineGrpcCase } from "./types.js";
+export { defineGrpcCase, grpcCase } from "./types.js";
 export type {
+  GrpcCaseBody,
   GrpcContractCase,
   GrpcContractDefaults,
   GrpcContractExample,

--- a/packages/grpc/src/contract/types.test-d.ts
+++ b/packages/grpc/src/contract/types.test-d.ts
@@ -2,11 +2,23 @@
  * Type-level tests for gRPC contract case factories.
  *
  * These are compile-only checks. They prove `defineGrpcCase<Needs>` locks the
- * logical input shape across `needs`, `request`, and `metadata`.
+ * logical input shape across `needs`, `request`, and `metadata`, and that the
+ * curried `grpcCase(schema)(case)` does the same with NOTHING defaulted: `N` is
+ * inferred from the schema VALUE (first call) and `C` from the case literal
+ * (second call), so the case keeps its literal type — which is what
+ * `InferGrpcResponse` / `InferGrpcRequest` read.
  */
 
-import { defineGrpcCase } from "../index.js";
+import { contract } from "@glubean/sdk";
 import type { SchemaLike } from "@glubean/sdk";
+import { defineGrpcCase, grpcCase } from "../index.js";
+import type {
+  GrpcCaseBody,
+  GrpcClient,
+  GrpcContractCase,
+  InferGrpcRequest,
+  InferGrpcResponse,
+} from "../index.js";
 
 function s<T>(): SchemaLike<T> {
   return {} as SchemaLike<T>;
@@ -37,4 +49,220 @@ function s<T>(): SchemaLike<T> {
     metadata: ({ missing }: { missing: string }) => ({ authorization: missing }),
   });
   void _metadataDrift;
+}
+
+// =============================================================================
+// grpcCase(schema)(case) — the curried factory.
+// =============================================================================
+
+declare const client: GrpcClient;
+const api = contract.grpc.with("api", { client });
+
+{
+  // ---------------------------------------------------------------------
+  // 1. Positive contextual typing: the action-field param IS the schema's
+  // output type — inferred, never annotated.
+  // ---------------------------------------------------------------------
+  const typedInput = grpcCase(s<{ token: string; userId: string }>())({
+    description: "fetch user",
+    request: (input) => {
+      // Proves `input` is `{token, userId}` and NOT implicitly `any` (which
+      // would make the drift assertions below vacuous). `any` here is the real
+      // hazard: `request?: Req | ((input) => Req)` collapses to `any` if the
+      // body type's `Req` slot is `any`, silently dropping the guard.
+      const userId: string = input.userId;
+      return { userId };
+    },
+    metadata: ({ token }) => ({ authorization: `Bearer ${token}` }),
+    expect: { statusCode: 0, schema: s<{ user: { id: string } }>() },
+    verify: async (_ctx, res) => {
+      // `res` is GrpcCaseResult<any> — see the factory's JSDoc for why it is
+      // NOT narrowed here (gRPC's `Res` is contract-level).
+      void res.message;
+      const code: number = res.status.code;
+      void code;
+    },
+  });
+  void typedInput;
+
+  // ---------------------------------------------------------------------
+  // 2. Drift guard: a key that is not on the schema is a compile error on
+  // every action field.
+  // ---------------------------------------------------------------------
+  const _driftRequest = grpcCase(s<{ userId: string }>())({
+    description: "drift request",
+    // @ts-expect-error -- `wrongKey` is not on Needs `{userId: string}`.
+    request: ({ wrongKey }) => ({ wrongKey }),
+  });
+  void _driftRequest;
+
+  const _driftMetadata = grpcCase(s<{ token: string }>())({
+    description: "drift metadata",
+    // @ts-expect-error -- `missing` is not on Needs `{token: string}`.
+    metadata: ({ missing }) => ({ authorization: missing }),
+  });
+  void _driftMetadata;
+
+  // ---------------------------------------------------------------------
+  // 3. Typed response preserved: `expect.schema` survives into the case's
+  // type, so `InferGrpcResponse` resolves it — the motivation for the
+  // curried shape.
+  // ---------------------------------------------------------------------
+  type CurriedResponse = InferGrpcResponse<typeof typedInput>;
+  const _responseIsTyped: CurriedResponse = { user: { id: "u1" } };
+  // @ts-expect-error -- response is `{user: {id: string}}`, so a wrong shape fails.
+  const _responseNotAny: CurriedResponse = { wrong: 1 };
+  // `unknown` is only assignable TO `unknown` — false here proves it resolved.
+  const _responseNotUnknown: [unknown] extends [CurriedResponse] ? true : false = false;
+  void _responseIsTyped;
+  void _responseNotAny;
+  void _responseNotUnknown;
+
+  // The request message resolves from the literal too. The second assertion
+  // rules out BOTH `unknown` and `any` (`[unknown] extends [any]` is also true).
+  type CurriedRequest = InferGrpcRequest<typeof typedInput>;
+  const _requestTyped: CurriedRequest = { userId: "u1" };
+  const _requestResolved: [unknown] extends [CurriedRequest] ? true : false = false;
+  void _requestTyped;
+  void _requestResolved;
+
+  // Contrast — the same case through defineGrpcCase degrades to `unknown`,
+  // because its nominal `GrpcContractCase<Req, Res, Needs>` return pins `Res`
+  // to the parameter's DEFAULT unless the author also spells it out.
+  const nominalCase = defineGrpcCase<{ userId: string }>({
+    description: "fetch user",
+    needs: s<{ userId: string }>(),
+    request: ({ userId }) => ({ userId }),
+    expect: { schema: s<{ user: { id: string } }>() },
+  });
+  const _nominalIsUnknown: [unknown] extends [InferGrpcResponse<typeof nominalCase>]
+    ? true
+    : false = true;
+  void _nominalIsUnknown;
+
+  // ---------------------------------------------------------------------
+  // 3b. An INTERFACE-typed request message is accepted. `GrpcCaseBody`'s `Req`
+  // slot is `object`, not `Record<string, unknown>` — protobuf codegen emits
+  // interfaces, which carry no implicit index signature and would be rejected
+  // by a record-shaped static branch.
+  // ---------------------------------------------------------------------
+  interface GetUserRequest {
+    userId: string;
+  }
+  const ifaceCase = grpcCase(s<{ userId: string }>())({
+    description: "interface-typed request message",
+    request: ({ userId }): GetUserRequest => ({ userId }),
+  });
+  void ifaceCase;
+
+  // ---------------------------------------------------------------------
+  // 4. Single declaration site: `needs` belongs to the factory call, never
+  // to the case literal (runtime throws on it too).
+  // ---------------------------------------------------------------------
+  const _doubleDeclared = grpcCase(s<{ userId: string }>())({
+    description: "declares needs twice",
+    // @ts-expect-error -- `needs` is owned by the factory; GrpcCaseBody pins
+    // the field to `never` so writing it here cannot compile.
+    needs: s<{ userId: string }>(),
+  });
+  void _doubleDeclared;
+
+  // ...but an explicit `needs: undefined` DECLARES NOTHING and compiles:
+  // `exactOptionalPropertyTypes` is off, so `needs?: never` admits undefined.
+  // The runtime tolerates it for exactly this reason (see grpc-case.test.ts) —
+  // the two layers must promise the same thing.
+  const _explicitUndefined = grpcCase(s<{ userId: string }>())({
+    description: "explicit undefined declares nothing",
+    needs: undefined,
+    request: ({ userId }) => ({ userId }),
+  });
+  void _explicitUndefined;
+
+  // ---------------------------------------------------------------------
+  // 5. Zero-arg form for cases with no logical input.
+  // ---------------------------------------------------------------------
+  const noNeedsCase = grpcCase()({
+    description: "no logical input",
+    expect: { statusCode: 0 },
+  });
+  const _assignableAsCase: GrpcContractCase = noNeedsCase;
+  void _assignableAsCase;
+
+  // Still one declaration site in the zero-arg form.
+  const _zeroArgDoubleDeclared = grpcCase()({
+    description: "declares needs without a factory schema",
+    // @ts-expect-error -- `needs` is owned by the factory in BOTH forms.
+    needs: s<{ userId: string }>(),
+  });
+  void _zeroArgDoubleDeclared;
+
+  // ---------------------------------------------------------------------
+  // 6. The returned case is accepted by the real contract factory, and the
+  // resulting `.case()` ref carries the per-case Needs.
+  // ---------------------------------------------------------------------
+  const users = api("user.fetch", {
+    target: "UserService/GetUser",
+    cases: { ok: typedInput, ping: noNeedsCase, iface: ifaceCase },
+  });
+
+  const okRef = users.case("ok");
+  type OkInput = typeof okRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _okInput: OkInput = { token: "t", userId: "u" };
+  // @ts-expect-error -- proves the ref input is Needs, not `any`.
+  const _okInputNotAny: OkInput = { completelyWrongField: "x" };
+  void _okInput;
+  void _okInputNotAny;
+}
+
+// =============================================================================
+// Regression: a case body written against the EXPORTED `GrpcCaseBody<N>`
+// annotation must survive the factory.
+//
+// `GrpcCaseBody` carries the `needs?: never` single-declaration guard, so a
+// bare `C & { needs: SchemaLike<N> }` return type intersects `never` with a
+// required property and collapses `needs` — taking core's `InferCaseInput` (and
+// with it the whole `.case()` I/O chain) down to `never`. The return type drops
+// the guarded key first (`Omit<C, "needs"> & ...`), which is what these assert.
+// =============================================================================
+
+{
+  type Needs = { email: string };
+
+  const preAnnotated: GrpcCaseBody<Needs> = {
+    description: "pre-annotated case body",
+    request: ({ email }) => ({ email }),
+  };
+
+  const built = grpcCase(s<Needs>())(preAnnotated);
+
+  // `needs` must be the schema, NOT `never`.
+  const _needsUsable: SchemaLike<Needs> = built.needs;
+  const _needsNotNever: [(typeof built)["needs"]] extends [never] ? true : false = false;
+  // Other fields stay reachable (a collapsed intersection makes the whole
+  // object unusable, not just its `needs`).
+  const _descReachable: string = built.description;
+  void _needsUsable;
+  void _needsNotNever;
+  void _descReachable;
+
+  // The whole `.case()` I/O chain still works off the built case, and the ref's
+  // input is EXACTLY Needs — asserted both ways, since a one-way `extends` also
+  // holds for `never`.
+  const preContract = api("user.signup", {
+    target: "UserService/Signup",
+    cases: { ok: built },
+  });
+  const preRef = preContract.case("ok");
+  type PreRefInput = typeof preRef extends { __phantom_inputs?: infer I } ? I : never;
+  const _inputIsExactlyNeeds: [PreRefInput] extends [Needs]
+    ? [Needs] extends [PreRefInput]
+      ? true
+      : false
+    : false = true;
+  void _inputIsExactlyNeeds;
+
+  // NOTE the deliberate non-assertion: annotating the body as
+  // `GrpcCaseBody<Needs>` WIDENS the literal, so `expect.schema` presence is
+  // erased and `InferGrpcResponse` degrades on this path. That is the cost of
+  // pre-annotating, not a regression — the inline-literal path keeps it.
 }

--- a/packages/grpc/src/contract/types.test-d.ts
+++ b/packages/grpc/src/contract/types.test-d.ts
@@ -155,6 +155,78 @@ const api = contract.grpc.with("api", { client });
   });
   void ifaceCase;
 
+  // An interface-typed VALUE is accepted in the static branch too, and so is a
+  // plain object literal — the `never` guards below must not cost either.
+  const ifaceValue = {} as GetUserRequest;
+  const ifaceStatic = grpcCase()({
+    description: "interface-typed static request",
+    request: ifaceValue,
+  });
+  const literalStatic = grpcCase()({
+    description: "object-literal static request",
+    request: { userId: "u1" },
+  });
+  void ifaceStatic;
+  void literalStatic;
+
+  // ---------------------------------------------------------------------
+  // 3c. The static branch must REJECT function values. A bare `object` static
+  // slot accepts every function (TS treats functions as objects), which
+  // re-admits three drift-bypassing forms — each corrupting the request at
+  // runtime, because `resolveRequest` calls anything `typeof === "function"`
+  // and deep-merges the result. See `GrpcRequestMessage`.
+  // ---------------------------------------------------------------------
+
+  // (i) A pre-declared builder whose ANNOTATED parameter drifts from the
+  // schema. The function branch rejects it on parameter contravariance; a
+  // permissive static branch would silently re-accept it and void the guard.
+  const driftingBuilder = (i: { wrongKey: string }) => ({ userId: i.wrongKey });
+  const _staticDrift = grpcCase(s<{ userId: string }>())({
+    description: "pre-declared builder with a drifting annotated param",
+    // @ts-expect-error -- neither branch may accept it: the function branch
+    // rejects the param, the static branch rejects callables.
+    request: driftingBuilder,
+  });
+  void _staticDrift;
+
+  // (ii) An `async` builder. Its Promise is not a message: deepMerge iterates
+  // `Object.entries(promise)` and sends `{}`.
+  const _asyncBuilder = grpcCase(s<{ userId: string }>())({
+    description: "async request builder",
+    // @ts-expect-error -- a Promise is not a request message (`then?: never`).
+    request: async ({ userId }) => ({ userId }),
+  });
+  void _asyncBuilder;
+
+  // (iii) A builder returning a PRIMITIVE. deepMerge would spread a string
+  // into `{0: "u", 1: "1", ...}`.
+  const _primitiveBuilder = grpcCase(s<{ userId: string }>())({
+    description: "request builder returning a primitive",
+    // @ts-expect-error -- a string is not a request message.
+    request: ({ userId }) => userId,
+  });
+  void _primitiveBuilder;
+
+  // ...and the union still does NOT collapse: a correctly shaped builder keeps
+  // full contextual typing (proved by the `string` annotation, which would fail
+  // on an implicit `any`) while a drifting key is still an error.
+  const _guardStillLive = grpcCase(s<{ userId: string; amount: number }>())({
+    description: "union did not collapse",
+    request: (input) => {
+      const userId: string = input.userId;
+      const amount: number = input.amount;
+      return { userId, amount };
+    },
+  });
+  void _guardStillLive;
+
+  const _guardStillLiveNegative = grpcCase(s<{ userId: string }>())({
+    description: "union did not collapse — negative",
+    // @ts-expect-error -- `nope` is not on Needs `{userId: string}`.
+    request: ({ nope }) => ({ nope }),
+  });
+  void _guardStillLiveNegative;
+
   // ---------------------------------------------------------------------
   // 4. Single declaration site: `needs` belongs to the factory call, never
   // to the case literal (runtime throws on it too).

--- a/packages/grpc/src/contract/types.ts
+++ b/packages/grpc/src/contract/types.ts
@@ -149,6 +149,12 @@ export interface GrpcContractCase<Req = unknown, Res = unknown, Needs = void>
  *
  * The default request type is a record rather than `unknown` so the static
  * branch does not swallow function values and bypass the `Needs` check.
+ *
+ * @deprecated Use {@link grpcCase} — same drift guard with zero explicit
+ * generics, and it keeps the case's literal type (so `InferGrpcResponse` /
+ * `InferGrpcRequest` resolve instead of degrading). Before:
+ * `defineGrpcCase<{ userId: string }>({ needs: Schema, request: ({ userId }) => ({ userId }) })`;
+ * after: `grpcCase(Schema)({ request: ({ userId }) => ({ userId }) })`.
  */
 export function defineGrpcCase<
   Needs = void,
@@ -156,6 +162,148 @@ export function defineGrpcCase<
   Res = unknown,
 >(c: GrpcContractCase<Req, Res, Needs>): GrpcContractCase<Req, Res, Needs> {
   return c;
+}
+
+/**
+ * Case body for {@link grpcCase} — `GrpcContractCase` WITHOUT `needs`; the
+ * factory owns that field.
+ *
+ * `needs` is pinned to `never` rather than merely omitted: TypeScript runs no
+ * excess-property check against a type parameter's CONSTRAINT, so a bare
+ * `Omit<...>` would silently absorb a stray `needs` key into the inferred case
+ * type and leave two competing declarations of the same schema. The `never`
+ * makes writing a schema there a compile error at the offending property. An
+ * explicit `needs: undefined` still passes — `exactOptionalPropertyTypes` is
+ * off in this repo and it declares nothing anyway.
+ *
+ * The `Req` slot is `object`, NOT `any`: `request?: Req | ((input: Needs) =>
+ * Req)` is a union whose static branch would SWALLOW the function branch if it
+ * were `any` (`any | F` collapses to `any`), and the drift guard would silently
+ * evaporate — the parameter of `request: ({ userId }) => ...` would go
+ * implicitly `any`. `object` is the widest static branch that still leaves the
+ * function branch visible, and unlike `defineGrpcCase`'s `Record<string,
+ * unknown>` default it accepts an INTERFACE-typed message (protobuf codegen
+ * emits interfaces, which have no implicit index signature and are therefore
+ * not assignable to `Record<string, unknown>`).
+ *
+ * The `Res` slot IS `any` (same as HTTP's `HttpCaseBody`): it only reaches
+ * `expect` and `verify`, never a union with a function, so it cannot swallow
+ * anything.
+ */
+export type GrpcCaseBody<N> = Omit<GrpcContractCase<object, any, N>, "needs"> & {
+  needs?: never;
+};
+
+/**
+ * Curried gRPC case factory — {@link defineGrpcCase}'s needs-drift guard with
+ * zero explicit generics, and without its type-erasing trade. Prefer this.
+ *
+ * **Why curried.** TypeScript can't correlate sibling fields of one object
+ * literal, so `needs: SchemaLike<X>` never types the `request: (input) => ...`
+ * written beside it — a factory has to capture `Needs` first. But TS also has
+ * no PARTIAL type-argument inference: the moment an author writes
+ * `defineGrpcCase<Needs>(...)`, every remaining type parameter falls back to its
+ * default and the case widens to the nominal `GrpcContractCase<Req, Res, Needs>`.
+ * Splitting the call in two leaves nothing to default — `N` is inferred from the
+ * schema VALUE in the first call, `C` from the case literal in the second
+ * (contextually typed by `GrpcCaseBody<N>`, which is what still threads `N` into
+ * the action fields).
+ *
+ * What that buys over `defineGrpcCase`:
+ * - **No explicit generics.** The schema is written once, as a value, and the
+ *   whole case is checked against it.
+ * - **Drift guard on both action fields** — `request` / `metadata` take
+ *   `(input: N) => ...`, so destructuring a key that isn't on `N` is a compile
+ *   error instead of a silently `undefined` field in the outgoing message.
+ * - **The case keeps its LITERAL type**, so `InferGrpcResponse` /
+ *   `InferGrpcRequest` resolve the real `expect.schema` / `request` types; the
+ *   nominal return of `defineGrpcCase` erases both to their defaults unless the
+ *   author also spells out `Req` and `Res` by hand.
+ * - **One declaration site.** A `needs` SCHEMA inside the case literal is both a
+ *   compile error (see {@link GrpcCaseBody}) and a runtime `Error`. The one
+ *   tolerated form is an explicit `needs: undefined`, which declares nothing:
+ *   `exactOptionalPropertyTypes` is off here, so `needs?: never` admits it, and
+ *   every runtime reader already treats undefined as "no needs" — rejecting it
+ *   would make the type layer and the runtime promise different things.
+ *
+ * Runtime output is VALUE-IDENTICAL to the pre-migration shape — a case that
+ * declared `needs` inline — because the factory only spreads the schema back
+ * in. Migrating an existing case moves neither its projection nor its
+ * `canonicalHash`.
+ *
+ * `verify(ctx, res)`'s `res` is `GrpcCaseResult<any>`, not inferred from
+ * `expect.schema` — that would need a second inference pass over the same
+ * literal. Do NOT annotate the parameter with a concrete result type: gRPC's
+ * `Res` is CONTRACT-level (`GrpcContractSpec<Req, Res, Cases>`) and infers
+ * `unknown`, so a narrowed `verify` parameter makes the case unassignable to the
+ * contract's `cases` (a pre-existing constraint — `defineGrpcCase<Needs, Req,
+ * Res>` with an explicit `Res` hits the same wall). Narrow `res.message` inside
+ * the body instead; the schema still validates the response at runtime.
+ *
+ * @example
+ * ```ts
+ * import { contract } from "@glubean/sdk";
+ * import { grpcCase } from "@glubean/grpc";
+ * import { z } from "zod";
+ *
+ * const fetchUser = grpcCase(z.object({ userId: z.string(), token: z.string() }))({
+ *   description: "fetches a user by id",
+ *   // `input` is { userId: string; token: string } — inferred, never annotated.
+ *   request: ({ userId }) => ({ userId }),
+ *   metadata: ({ token }) => ({ authorization: `Bearer ${token}` }),
+ *   expect: { statusCode: 0, schema: z.object({ user: z.object({ id: z.string() }) }) },
+ * });
+ *
+ * const api = contract.grpc.with("users", { client });
+ * export const users = api("user.fetch", {
+ *   target: "UserService/GetUser",
+ *   cases: { fetchUser },
+ * });
+ * ```
+ *
+ * @param needs The case's logical input schema — declared here, exactly once.
+ *   Omit the argument entirely for a case with no logical input; that form
+ *   returns the case unchanged and still rejects a literal `needs`.
+ * @returns A function taking the case literal, returning it with `needs` attached.
+ */
+export function grpcCase<N>(
+  needs: SchemaLike<N>,
+): <const C extends GrpcCaseBody<N>>(
+  c: C,
+  // `Omit<C, "needs">` before the intersection, never a bare `C & {...}`: a case
+  // written against the exported `GrpcCaseBody<X>` annotation carries the
+  // `needs?: never` guard INTO `C`, and intersecting that with the required
+  // `needs: SchemaLike<N>` collapses the property (and with it core's
+  // `InferCaseInput`, and with THAT the whole `.case()` I/O chain) to `never`.
+  // Dropping the guarded key first keeps every other property's literal type
+  // intact.
+) => Omit<C, "needs"> & { needs: SchemaLike<N> };
+export function grpcCase(): <const C extends GrpcCaseBody<void>>(c: C) => C;
+export function grpcCase(needs?: SchemaLike<unknown>) {
+  // Keep JS consumers aligned with the type-level `needs?: never` — a literal
+  // `needs` SCHEMA is a hard error in BOTH forms, so it always has exactly one
+  // declaration site. The zero-arg form returns the case unchanged.
+  //
+  // The two overloads above are the checked authoring surface; this
+  // implementation is untyped glue (a concrete param type is not compatible
+  // with both of them).
+  return (c: any) => {
+    // Value check, NOT hasOwnProperty: `exactOptionalPropertyTypes` is off in
+    // this repo, so `needs?: never` accepts an explicit `needs: undefined` and
+    // the runtime must accept it too, or the two layers promise different
+    // things. Tolerating it is safe because every runtime reader treats
+    // undefined as "no needs declared" (core's §5.1 branches are falsy checks;
+    // the projection records `hasNeeds: c.needs !== undefined`). In the schema
+    // form the spread below overwrites the key anyway.
+    if (c.needs !== undefined) {
+      throw new Error(
+        "grpcCase: do not declare `needs` inside the case literal — the factory " +
+          "owns that field. Declare it once as `grpcCase(schema)({ ... })` and " +
+          "remove `needs` from the case object.",
+      );
+    }
+    return needs === undefined ? c : { ...c, needs };
+  };
 }
 
 // =============================================================================

--- a/packages/grpc/src/contract/types.ts
+++ b/packages/grpc/src/contract/types.ts
@@ -165,6 +165,43 @@ export function defineGrpcCase<
 }
 
 /**
+ * A gRPC request MESSAGE value — any object that is neither callable nor
+ * thenable. This is the static branch of {@link GrpcCaseBody}'s `request`
+ * union, and (because `GrpcContractCase` uses one parameter for both) also the
+ * return type its function branch must produce.
+ *
+ * **Why the `never` guards.** `request?: Req | ((input) => Req)` is a union, so
+ * a plain `object` static branch ACCEPTS function values — TypeScript treats
+ * every function as an `object` — and three real authoring mistakes slip
+ * through it with zero errors, each producing a corrupt request at runtime
+ * (`resolveRequest` calls anything `typeof === "function"` and hands the result
+ * to `deepMerge`):
+ *
+ * 1. A pre-declared builder whose ANNOTATED parameter drifts from the schema.
+ *    The function branch rejects it (parameter contravariance), the `object`
+ *    branch silently re-accepts it, and the needs-drift guard is bypassed.
+ * 2. An `async` builder. Its `Promise` is not a valid message; `deepMerge`
+ *    iterates `Object.entries(promise)` and sends `{}` — an empty request.
+ * 3. A builder returning a primitive. `deepMerge` spreads a string into
+ *    `{0: "a", 1: "b", ...}`.
+ *
+ * `apply` / `call` / `bind` are present on every function type, so pinning them
+ * to `never` excludes callables while a protobuf message (an interface with no
+ * such fields) passes the optional-property check untouched. `then` excludes
+ * the `Promise` from case 2 — and a thenable message is hazardous regardless.
+ *
+ * The cost: a message with a literal `apply` / `call` / `bind` / `then` FIELD
+ * cannot go through {@link grpcCase}. That shape keeps using the deprecated
+ * `defineGrpcCase<Needs, Req, Res>`, which takes `Req` explicitly.
+ */
+export type GrpcRequestMessage = object & {
+  apply?: never;
+  call?: never;
+  bind?: never;
+  then?: never;
+};
+
+/**
  * Case body for {@link grpcCase} — `GrpcContractCase` WITHOUT `needs`; the
  * factory owns that field.
  *
@@ -176,21 +213,25 @@ export function defineGrpcCase<
  * explicit `needs: undefined` still passes — `exactOptionalPropertyTypes` is
  * off in this repo and it declares nothing anyway.
  *
- * The `Req` slot is `object`, NOT `any`: `request?: Req | ((input: Needs) =>
- * Req)` is a union whose static branch would SWALLOW the function branch if it
- * were `any` (`any | F` collapses to `any`), and the drift guard would silently
- * evaporate — the parameter of `request: ({ userId }) => ...` would go
- * implicitly `any`. `object` is the widest static branch that still leaves the
- * function branch visible, and unlike `defineGrpcCase`'s `Record<string,
- * unknown>` default it accepts an INTERFACE-typed message (protobuf codegen
- * emits interfaces, which have no implicit index signature and are therefore
- * not assignable to `Record<string, unknown>`).
+ * The `Req` slot is {@link GrpcRequestMessage}, NOT `any`: `request?: Req |
+ * ((input: Needs) => Req)` is a union whose static branch would SWALLOW the
+ * function branch if it were `any` (`any | F` collapses to `any`), and the
+ * drift guard would silently evaporate — the parameter of `request: ({ userId
+ * }) => ...` would go implicitly `any`. It is not a bare `object` either: that
+ * accepts function VALUES and re-admits three drift-bypassing forms through the
+ * static branch (see {@link GrpcRequestMessage}). Unlike `defineGrpcCase`'s
+ * `Record<string, unknown>` default it still accepts an INTERFACE-typed message
+ * (protobuf codegen emits interfaces, which have no implicit index signature
+ * and are therefore not assignable to `Record<string, unknown>`).
  *
  * The `Res` slot IS `any` (same as HTTP's `HttpCaseBody`): it only reaches
  * `expect` and `verify`, never a union with a function, so it cannot swallow
  * anything.
  */
-export type GrpcCaseBody<N> = Omit<GrpcContractCase<object, any, N>, "needs"> & {
+export type GrpcCaseBody<N> = Omit<
+  GrpcContractCase<GrpcRequestMessage, any, N>,
+  "needs"
+> & {
   needs?: never;
 };
 

--- a/packages/grpc/src/index.ts
+++ b/packages/grpc/src/index.ts
@@ -561,9 +561,11 @@ export {
   createGrpcFactory,
   createGrpcRoot,
   defineGrpcCase,
+  grpcCase,
   grpcMatchers,
 } from "./contract/index.js";
 export type {
+  GrpcCaseBody,
   GrpcContractCase,
   GrpcContractDefaults,
   GrpcContractExample,

--- a/packages/grpc/src/index.ts
+++ b/packages/grpc/src/index.ts
@@ -578,6 +578,7 @@ export type {
   GrpcCaseResult,
   GrpcFlowCaseOutput,
   GrpcPayloadSchemas,
+  GrpcRequestMessage,
   GrpcSafeSchemas,
   InferGrpcRequest,
   InferGrpcResponse,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,7 +38,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run"
+    "test": "vitest run && npm run test:types",
+    "test:types": "tsc -p tsconfig.typetest.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/tsconfig.typetest.json
+++ b/packages/sdk/tsconfig.typetest.json
@@ -1,0 +1,19 @@
+{
+  // Type-assertion gate: production `src` PLUS the `*.test-d.ts` files, which
+  // `tsconfig.build.json` excludes and therefore never checks. Wired into the
+  // package's `test` script so `pnpm -r test` enforces it with no CI workflow
+  // changes.
+  //
+  // `*.test.ts` is excluded deliberately: those files carry pre-existing type
+  // errors (8 at the time of writing, in configure/index/load/workflow tests)
+  // that have nothing to do with the type assertions this gate protects.
+  // Including them would make the gate red on day one and force it to be
+  // ignored. Vitest still runs them; only `tsc` skips them.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
Fixes #29
Fixes #33

## What

Ports the curried case-factory pattern shipped for HTTP in 0.13.0 (#27) to the three sibling protocols, and adds a CI gate for `*.test-d.ts` type assertions.

- `graphqlCase(needs?)(...)` / `grpcCase(needs?)(...)` / `browserCase(needs?)(...)` — zero explicit generics, needs-drift guard, literal-preserving return; the old `defineXxxCase` factories stay functional and are `@deprecated`.
- `packages/sdk` test script now runs a dedicated `tsconfig.typetest.json` so type assertions are enforced by `pnpm -r test` (they were previously checked by nothing).

## Protocol-specific decisions (all spike-verified)

- **graphql** — the Vars slot must not be `any`: `variables?: Vars | ((input) => Vars)` is a union and `any | F` collapses, silently killing the drift guard. `Record<string, unknown>` keeps it live.
- **grpc** — the static request slot is the new exported `GrpcRequestMessage` (`object & { apply/call/bind/then?: never }`): bare `object` accepts function values (three drift-bypassing shapes reproduced in review), and `apply/call/bind` alone is insufficient because `Req` is also the function branch's return type — an async builder's Promise re-enters unless `then` is pinned. Protobuf interfaces (no implicit index signature) remain accepted; messages with fields literally named `apply`/`call`/`bind`/`then` keep `defineGrpcCase` as the escape hatch.
- **browser** — `PageType` has no schema to infer from; the factory recovers it through two value routes (restated `steps` in the return type + optional `client` param). Two remaining gaps are precisely documented and pinned in test-d: standalone + client-less extension cases, and spec-level `client` (two real-fix attempts both regressed the working `.with()` path). Only `.with(...)` substitutes — a case-level client cannot widen a contract (parameter contravariance).

## Recommendation surfaces

READMEs (graphql/grpc quick-starts previously taught the unguarded inline-`needs` shape), the browser side-panel guide, and the authoring-surface comment now all teach the curried factories. Deprecated-factory usage inside test files is kept deliberately as regression coverage of the deprecated path.

## Verification

Full workspace `CI=1 pnpm -r build` / `CI=1 pnpm -r test` green (sdk 718, graphql 111, grpc 81, browser 283). Per-package type tests cover drift both directions, literal-`needs` rejection + explicit-undefined tolerance, pre-annotated case-body regression, and typed-response preservation with deprecated-factory degradation contrasts. The test-d gate was proven live by breaking one assertion per package (each failed the package's test script, invisible to vitest alone). README/guide snippets were compiled verbatim against the real package types, with a negative control proving the drift guard is live in the taught examples.

Converged under the cross-host review gate: 4 rounds, foundation threshold (all findings including nits at zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)