### PR TITLE
sdk: type/runtime truthfulness — fatal narrowing, example drift warnings, .json(schema)

### DIFF
--- a/packages/runner/src/engine-parity.test.ts
+++ b/packages/runner/src/engine-parity.test.ts
@@ -337,6 +337,14 @@ export const validateFatalTest = test(
   { id: "validateFatalTest", name: "Validate Fatal" },
   async (ctx) => { ctx.validate({}, failSchema, "hard", { severity: "fatal" }); ctx.assert(true, "unreached"); }
 );
+// GLU-90 jsonSchema-only SchemaLike: no safeParse, no parse. Nothing can prove
+// the data valid, so fatal must abort on BOTH legs (the fatal overload narrows
+// the return type to T, so "returns undefined without throwing" would be a lie).
+const noParserSchema = { jsonSchema: { type: "object" } };
+export const validateNoParserFatalTest = test(
+  { id: "validateNoParserFatalTest", name: "Validate No Parser Fatal" },
+  async (ctx) => { ctx.validate({}, noParserSchema, "no-parser", { severity: "fatal" }); ctx.assert(true, "unreached"); }
+);
 const throwSchema = { parse: () => { const e = new Error("nope"); e.issues = [{ message: "p issue", path: ["x"] }]; throw e; } };
 export const validateParseFallbackTest = test(
   { id: "validateParseFallbackTest", name: "Validate parse fallback" },
@@ -754,6 +762,10 @@ ptest("engine parity: ctx.validate warn → schema_validation + warning (test pa
 
 ptest("engine parity: ctx.validate fatal → failed assertion + abort (failed + exit 1)", async () => {
   await assertParity(MODULE, "validateFatalTest");
+});
+
+ptest("engine parity: ctx.validate fatal with a NO-parser schema → failed assertion + abort", async () => {
+  await assertParity(MODULE, "validateNoParserFatalTest");
 });
 
 ptest("engine parity: ctx.validate parse() fallback path (throws → issues extracted)", async () => {

--- a/packages/runner/src/executor.test.ts
+++ b/packages/runner/src/executor.test.ts
@@ -1658,6 +1658,20 @@ export const validateFatalTest = test(
   },
 );
 
+export const validateNoParserFatalTest = test(
+  { id: "validateNoParserFatalTest", name: "Validate No Parser Fatal" },
+  async (ctx) => {
+    // A GLU-90 SchemaLike carrying only a jsonSchema companion — no safeParse,
+    // no parse. Nothing can prove the data valid, so a fatal validation must
+    // abort (the fatal overload narrows the return type to T).
+    const jsonSchemaOnly = { jsonSchema: { type: "object" } };
+    ctx.validate({ anything: true }, jsonSchemaOnly, "no-parser", {
+      severity: "fatal",
+    });
+    ctx.log("after no-parser fatal — should never reach here");
+  },
+);
+
 export const validateParseFallbackTest = test(
   { id: "validateParseFallbackTest", name: "Validate Parse Fallback" },
   async (ctx) => {
@@ -1756,6 +1770,33 @@ test("ctx.validate - fatal severity aborts test", async () => {
 
   const logs = result.events.filter(
     (e) => e.type === "log" && "message" in e && e.message.includes("after fatal"),
+  );
+  expect(logs.length).toBe(0);
+});
+
+test("ctx.validate - fatal severity aborts when the schema has NO parser", async () => {
+  const testFile = await makeTempFile(VALIDATE_TEST_CONTENT);
+  const executor = new TestExecutor();
+
+  const result = await executor.execute(
+    `file://${testFile}`,
+    "validateNoParserFatalTest",
+    { vars: {}, secrets: {} },
+  );
+
+  expect(result.success).toBe(false);
+
+  const validations = getSchemaValidations(result.events);
+  expect(validations.length).toBe(1);
+  expect(validations[0].success).toBe(false);
+  expect(validations[0].severity).toBe("fatal");
+  expect(validations[0].issues?.[0]?.message).toMatch(/neither safeParse nor parse/);
+
+  // The call must NOT return — an unvalidatable schema can't produce the `T`
+  // the fatal overload promises.
+  const logs = result.events.filter(
+    (e) =>
+      e.type === "log" && "message" in e && e.message.includes("after no-parser fatal"),
   );
   expect(logs.length).toBe(0);
 });

--- a/packages/runner/src/workflow/execute.test.ts
+++ b/packages/runner/src/workflow/execute.test.ts
@@ -405,6 +405,41 @@ describe("makeNodeScope — seal drops late evidence; flags track failure/struct
     expect(rec.logs).toHaveLength(0); // dropped
   });
 
+  it("fatal validation aborts control flow even after seal(); non-fatal stays silent", () => {
+    const { ctx, rec } = fakeBase();
+    const ac = new AbortController();
+    const scope = makeNodeScope(ctx, ac.signal);
+    const failing = { safeParse: () => ({ success: false }) };
+
+    // Live baseline: throws AND records the failure.
+    expect(() =>
+      scope.ctx.validate({}, failing as never, "live", { severity: "fatal" }),
+    ).toThrow(/fatal validation/);
+    expect(rec.validations).toBe(1);
+    expect(scope.hasFailure()).toBe(true);
+
+    const { ctx: ctx2, rec: rec2 } = fakeBase();
+    const scope2 = makeNodeScope(ctx2, new AbortController().signal);
+    scope2.seal();
+
+    // Non-fatal after seal: silent — no delegated evidence, verdict untouched.
+    expect(scope2.ctx.validate({}, failing as never, "soft")).toBeUndefined();
+    expect(rec2.validations).toBe(0);
+    expect(scope2.hasFailure()).toBe(false);
+
+    // Fatal after seal: the THROW is control flow, not evidence (same split as
+    // `fail`/`skip`), so it must still abort the orphaned body — otherwise the
+    // body sails past a failed fatal validation and keeps running side effects,
+    // and `ctx.validate(..., { severity: "fatal" })` returns `undefined` despite
+    // its narrowed `T` return type.
+    expect(() =>
+      scope2.ctx.validate({}, failing as never, "hard", { severity: "fatal" }),
+    ).toThrow(/fatal validation/);
+    // …while STILL leaking no late evidence and not rewriting the verdict.
+    expect(rec2.validations).toBe(0);
+    expect(scope2.hasFailure()).toBe(false);
+  });
+
   it("promoteGrade only lifts opaque, and only with structured evidence", () => {
     const { ctx } = fakeBase();
     const ac = new AbortController();

--- a/packages/runner/src/workflow/execute.ts
+++ b/packages/runner/src/workflow/execute.ts
@@ -352,9 +352,13 @@ export function makeNodeScope(base: TestContext, signal: AbortSignal): NodeScope
       onEvidence({ failed: !ok && severity !== "warn", structured: true }, () =>
         (base.validate as (...args: unknown[]) => unknown)(data, schema, label, options),
       );
-      // `severity: "fatal"` aborts the body at the validation point — preserve
-      // that control flow, but only while live (a sealed node is already done).
-      if (live && !ok && severity === "fatal") {
+      // `severity: "fatal"` aborts the body at the validation point. The throw is
+      // CONTROL FLOW, not evidence, so it fires regardless of liveness — same
+      // split as `fail` below (emit gated, throw always) and `skip`. Gating it on
+      // `live` used to let an orphaned body sail past a failed fatal validation
+      // and keep running its side effects, and made `ctx.validate(..., {severity:
+      // "fatal"})` return `undefined` even though its type says it returns `T`.
+      if (!ok && severity === "fatal") {
         throw new Error(`fatal validation failed: ${label ?? "data"}`);
       }
       return value;

--- a/packages/sdk/src/configure/http.ts
+++ b/packages/sdk/src/configure/http.ts
@@ -9,8 +9,9 @@
  *   http options are declared in configure().
  */
 
-import type { ConfigureHttpOptions, HttpClient } from "../types.js";
+import type { ConfigureHttpOptions, ConfiguredHttpClient, HttpClient } from "../types.js";
 import { getRuntime, type InternalRuntime } from "./runtime.js";
+import { makeSchemaAwareClient } from "./schema-json.js";
 import { resolveTemplate } from "./template.js";
 
 /**
@@ -19,7 +20,7 @@ import { resolveTemplate } from "./template.js";
  * Result is cached per runtime identity via WeakMap.
  * @internal
  */
-export function buildLazyHttp(httpOptions: ConfigureHttpOptions): HttpClient {
+export function buildLazyHttp(httpOptions: ConfigureHttpOptions): ConfiguredHttpClient {
   const cache = new WeakMap<InternalRuntime, HttpClient>();
 
   function getClient(): HttpClient {
@@ -79,20 +80,13 @@ export function buildLazyHttp(httpOptions: ConfigureHttpOptions): HttpClient {
     return client;
   }
 
-  const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head"] as const;
-
-  const proxy: any = function (url: string | URL | Request, options?: any) {
-    return getClient()(url, options);
-  };
-
-  for (const method of HTTP_METHODS) {
-    proxy[method] = (url: string | URL | Request, options?: any) => getClient()[method](url, options);
-  }
-
-  proxy.extend = (options: any) => getClient().extend(options);
+  // The wrapper decorates every response promise with the schema-aware
+  // `.json(schema)` form (issue #32); dispatch stays lazy — `getClient()` is
+  // still resolved per call, exactly as before.
+  const proxy = makeSchemaAwareClient(getClient);
   (proxy as any)._configuredTimeout = httpOptions.timeout;
 
-  return proxy as HttpClient;
+  return proxy;
 }
 
 /**
@@ -100,18 +94,8 @@ export function buildLazyHttp(httpOptions: ConfigureHttpOptions): HttpClient {
  * Used when configure() is called without http options.
  * @internal
  */
-export function buildPassthroughHttp(): HttpClient {
-  const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head"] as const;
-
-  const proxy: any = function (url: string | URL | Request, options?: any) {
-    return getRuntime().http(url, options);
-  };
-
-  for (const method of HTTP_METHODS) {
-    proxy[method] = (url: string | URL | Request, options?: any) => getRuntime().http[method](url, options);
-  }
-
-  proxy.extend = (options: any) => getRuntime().http.extend(options);
-
-  return proxy as HttpClient;
+export function buildPassthroughHttp(): ConfiguredHttpClient {
+  // Same lazy delegation as before (the runtime is resolved per call, so a
+  // missing runtime still throws at call time), plus `.json(schema)`.
+  return makeSchemaAwareClient(() => getRuntime().http);
 }

--- a/packages/sdk/src/configure/schema-json.test.ts
+++ b/packages/sdk/src/configure/schema-json.test.ts
@@ -11,6 +11,7 @@
 import { test, expect, afterEach } from "vitest";
 import { z } from "zod";
 import { configure } from "../configure.js";
+import { CONFIGURED_HTTP_CLIENT, SCHEMA_JSON_ATTACHED } from "../types.js";
 import { parseWithSchema } from "./schema-json.js";
 import {
   setRuntime as carrierSetRuntime,
@@ -228,6 +229,31 @@ test("json(schema) survives .extend() on the configured client", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Nominal brands (the type-level guard has a runtime counterpart)
+// ---------------------------------------------------------------------------
+
+test("the configured client and its response promises carry the runtime brands", async () => {
+  const cleanup = installRuntime({ id: "u1", name: "Alice" });
+  try {
+    const { http } = configure({});
+    expect((http as unknown as Record<PropertyKey, unknown>)[CONFIGURED_HTTP_CLIENT]).toBe(true);
+
+    const extended = http.extend({ prefixUrl: "https://api.example.com" });
+    expect((extended as unknown as Record<PropertyKey, unknown>)[CONFIGURED_HTTP_CLIENT]).toBe(
+      true,
+    );
+
+    const promise = http.get("users/1");
+    expect((promise as unknown as Record<PropertyKey, unknown>)[SCHEMA_JSON_ATTACHED]).toBe(true);
+    const tracked = promise.track("GET /users/:id");
+    expect((tracked as unknown as Record<PropertyKey, unknown>)[SCHEMA_JSON_ATTACHED]).toBe(true);
+    await promise;
+  } finally {
+    cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // parseWithSchema unit behaviour
 // ---------------------------------------------------------------------------
 
@@ -241,6 +267,23 @@ test("parseWithSchema prefers parse so the schema's own error propagates", () =>
     }
   })();
   expect(zodError).toBeInstanceOf(z.ZodError);
+});
+
+test("parseWithSchema survives a symbol segment in an issue path", () => {
+  const symbolKey = Symbol("secret");
+  const symbolPath: SchemaLike<unknown> = {
+    safeParse() {
+      return {
+        success: false as const,
+        // `Array#join` throws a TypeError on a symbol segment; the summary must
+        // stringify each segment instead of blowing up the caller's error.
+        error: { issues: [{ message: "Expected string", path: [symbolKey] }] },
+      };
+    },
+  };
+  expect(() => parseWithSchema({}, symbolPath)).toThrow(
+    /Symbol\(secret\): Expected string/,
+  );
 });
 
 test("parseWithSchema summarizes at most 3 issues for a safeParse-only schema", () => {

--- a/packages/sdk/src/configure/schema-json.test.ts
+++ b/packages/sdk/src/configure/schema-json.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the schema-aware `.json(schema)` on the `configure()` HTTP client
+ * (issue #32).
+ *
+ * The underlying response promise comes from the runner/engine (ky's
+ * `ResponsePromise`); here a fake runtime supplies a ky-shaped double so the
+ * decoration itself is under test: schema form validates, no-arg form is
+ * untouched, `.track()` and `.extend()` keep the capability.
+ */
+
+import { test, expect, afterEach } from "vitest";
+import { z } from "zod";
+import { configure } from "../configure.js";
+import { parseWithSchema } from "./schema-json.js";
+import {
+  setRuntime as carrierSetRuntime,
+  type InternalRuntime,
+} from "../runtime-carrier.js";
+import type { HttpClient, SchemaLike } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// ky-shaped test double
+// ---------------------------------------------------------------------------
+
+interface FakeCall {
+  method: string;
+  url: string;
+  tracked: string[];
+}
+
+/** A promise carrying ky's body shortcuts (`json` / `text`) plus `.track()`. */
+function makeResponsePromise(body: unknown, tracked: string[]) {
+  const promise = Promise.resolve({ status: 200 } as unknown as Response) as Promise<Response> & {
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+    track: (pattern: string) => unknown;
+  };
+  promise.json = async () => body;
+  promise.text = async () => JSON.stringify(body);
+  promise.track = (pattern: string) => {
+    tracked.push(pattern);
+    return promise;
+  };
+  return promise;
+}
+
+function makeRuntimeHttp(body: unknown, calls: FakeCall[] = []): HttpClient {
+  const tracked: string[] = [];
+  const respond = (method: string) => (url: string | URL | Request) => {
+    calls.push({ method, url: String(url), tracked });
+    return makeResponsePromise(body, tracked);
+  };
+  const client = respond("get") as unknown as Record<string, unknown>;
+  for (const method of ["get", "post", "put", "patch", "delete", "head"]) {
+    client[method] = respond(method);
+  }
+  client["extend"] = () => makeRuntimeHttp(body, calls);
+  return client as unknown as HttpClient;
+}
+
+function installRuntime(body: unknown, calls: FakeCall[] = []): () => void {
+  const runtime: InternalRuntime = {
+    vars: {},
+    secrets: {},
+    session: {},
+    http: makeRuntimeHttp(body, calls),
+  };
+  carrierSetRuntime(runtime);
+  return () => carrierSetRuntime(undefined);
+}
+
+afterEach(() => {
+  carrierSetRuntime(undefined);
+});
+
+const UserSchema = z.object({ id: z.string(), name: z.string() });
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+test("json(schema) returns the validated value", async () => {
+  const cleanup = installRuntime({ id: "u1", name: "Alice" });
+  try {
+    const { http } = configure({});
+    const user = await http.get("users/1").json(UserSchema);
+    expect(user).toEqual({ id: "u1", name: "Alice" });
+    // Typed as z.infer<typeof UserSchema> — no cast needed.
+    const id: string = user.id;
+    expect(id).toBe("u1");
+  } finally {
+    cleanup();
+  }
+});
+
+test("json(schema) returns the schema's PARSED output, not the raw body", async () => {
+  const cleanup = installRuntime({ count: "42" });
+  try {
+    const { http } = configure({});
+    const Coerced = z.object({ count: z.coerce.number() });
+    const parsed = await http.get("stats").json(Coerced);
+    expect(parsed).toEqual({ count: 42 });
+  } finally {
+    cleanup();
+  }
+});
+
+test("json(schema) works on the configured (extend-backed) client too", async () => {
+  const cleanup = installRuntime({ id: "u1", name: "Alice" });
+  try {
+    const { http } = configure({ http: { prefixUrl: "https://api.example.com" } });
+    const user = await http.get("users/1").json(UserSchema);
+    expect(user).toEqual({ id: "u1", name: "Alice" });
+  } finally {
+    cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Failure modes
+// ---------------------------------------------------------------------------
+
+test("json(schema) throws exactly what a parse-style schema throws", async () => {
+  const cleanup = installRuntime({ id: "u1" });
+  try {
+    const { http } = configure({});
+    await expect(http.get("users/1").json(UserSchema)).rejects.toBeInstanceOf(z.ZodError);
+  } finally {
+    cleanup();
+  }
+});
+
+test("json(schema) throws an issue-summary Error for a safeParse-only schema", async () => {
+  const cleanup = installRuntime({ id: 7 });
+  try {
+    const safeParseOnly: SchemaLike<{ id: string }> = {
+      safeParse(data: unknown) {
+        const id = (data as { id?: unknown })?.id;
+        return typeof id === "string"
+          ? { success: true as const, data: { id } }
+          : {
+              success: false as const,
+              error: { issues: [{ message: "Expected string", path: ["id"] }] },
+            };
+      },
+    };
+
+    const { http } = configure({});
+    await expect(http.get("users/1").json(safeParseOnly)).rejects.toThrow(
+      /Schema validation failed — id: Expected string/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("json(schema) rejects a schema with neither parse nor safeParse", async () => {
+  const cleanup = installRuntime({ id: "u1" });
+  try {
+    const { http } = configure({});
+    const useless = { jsonSchema: { type: "object" } } as SchemaLike<unknown>;
+    await expect(http.get("users/1").json(useless)).rejects.toBeInstanceOf(TypeError);
+  } finally {
+    cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unchanged surface
+// ---------------------------------------------------------------------------
+
+test("no-arg json<T>() is unchanged — decoded body, no validation", async () => {
+  const cleanup = installRuntime({ id: 7, unexpected: true });
+  try {
+    const { http } = configure({});
+    const raw = await http.get("users/1").json<unknown>();
+    expect(raw).toEqual({ id: 7, unexpected: true });
+  } finally {
+    cleanup();
+  }
+});
+
+test("other body shortcuts and awaiting the response still work", async () => {
+  const cleanup = installRuntime({ id: "u1", name: "Alice" });
+  try {
+    const { http } = configure({});
+    const text = await http.get("users/1").text();
+    expect(text).toBe(JSON.stringify({ id: "u1", name: "Alice" }));
+
+    const res = await http.get("users/1");
+    expect(res.status).toBe(200);
+  } finally {
+    cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Chaining
+// ---------------------------------------------------------------------------
+
+test("json(schema) survives a .track(...) chain", async () => {
+  const calls: FakeCall[] = [];
+  const cleanup = installRuntime({ id: "u1", name: "Alice" }, calls);
+  try {
+    const { http } = configure({});
+    const user = await http.get("users/u1").track("GET /users/:id").json(UserSchema);
+    expect(user).toEqual({ id: "u1", name: "Alice" });
+    expect(calls[0]?.tracked).toEqual(["GET /users/:id"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("json(schema) survives .extend() on the configured client", async () => {
+  const cleanup = installRuntime({ id: "u1", name: "Alice" });
+  try {
+    const { http } = configure({});
+    const api = http.extend({ prefixUrl: "https://api.example.com" });
+    const user = await api.get("users/1").json(UserSchema);
+    expect(user).toEqual({ id: "u1", name: "Alice" });
+
+    const nested = api.extend({ timeout: 1000 });
+    const again = await nested.post("users").json(UserSchema);
+    expect(again).toEqual({ id: "u1", name: "Alice" });
+  } finally {
+    cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// parseWithSchema unit behaviour
+// ---------------------------------------------------------------------------
+
+test("parseWithSchema prefers parse so the schema's own error propagates", () => {
+  const zodError = (() => {
+    try {
+      parseWithSchema({ id: 1 }, UserSchema);
+      return null;
+    } catch (err) {
+      return err;
+    }
+  })();
+  expect(zodError).toBeInstanceOf(z.ZodError);
+});
+
+test("parseWithSchema summarizes at most 3 issues for a safeParse-only schema", () => {
+  const many: SchemaLike<unknown> = {
+    safeParse() {
+      return {
+        success: false as const,
+        error: {
+          issues: [
+            { message: "m1", path: ["a"] },
+            { message: "m2", path: ["b"] },
+            { message: "m3", path: ["c"] },
+            { message: "m4", path: ["d"] },
+          ],
+        },
+      };
+    },
+  };
+  expect(() => parseWithSchema({}, many)).toThrow(
+    /a: m1; b: m2; c: m3 \(\+1 more\)/,
+  );
+});

--- a/packages/sdk/src/configure/schema-json.ts
+++ b/packages/sdk/src/configure/schema-json.ts
@@ -1,0 +1,141 @@
+/**
+ * @module configure/schema-json
+ *
+ * Schema-aware `.json(schema)` for the `configure()` HTTP client (issue #32).
+ *
+ * The recurring authoring pattern is:
+ *
+ * ```ts
+ * const raw = await http.get(url).json<unknown>();
+ * const user = UserSchema.parse(raw);
+ * ```
+ *
+ * `.json(schema)` collapses that into one call: decode the body, run it through
+ * the schema, return the VALIDATED value typed from the schema. The no-arg
+ * `.json<T>()` form is untouched — it still returns the decoded body with `T` as
+ * an author assertion.
+ *
+ * The runner/engine build the underlying response promise (ky's
+ * `ResponsePromise`, possibly already patched for `schema:` option validation);
+ * we only decorate the object the configured client hands back, so every
+ * existing behaviour (`text()`, `blob()`, `track()`, `await`) is preserved.
+ */
+
+import type {
+  ConfiguredHttpClient,
+  HttpClient,
+  HttpRequestOptions,
+  SchemaLike,
+} from "../types.js";
+
+/** Marks a response promise whose `json` already accepts a schema. */
+const SCHEMA_JSON_ATTACHED = Symbol.for("glubean.schemaJsonAttached");
+
+/** Max issues quoted when a `safeParse`-only schema rejects the body. */
+const MAX_QUOTED_ISSUES = 3;
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head"] as const;
+
+/**
+ * Validate a decoded body with a `SchemaLike`.
+ *
+ * `parse` is preferred so the caller sees EXACTLY what their schema library
+ * throws (e.g. a `ZodError`, with its issues intact). A `safeParse`-only schema
+ * has no error to re-throw, so we raise an `Error` carrying the issue summary.
+ */
+export function parseWithSchema<T>(data: unknown, schema: SchemaLike<T>): T {
+  if (typeof schema.parse === "function") {
+    return schema.parse(data);
+  }
+  if (typeof schema.safeParse === "function") {
+    const result = schema.safeParse(data);
+    if (result.success) return result.data;
+    const issues = result.error?.issues ?? [];
+    const quoted = issues.slice(0, MAX_QUOTED_ISSUES).map((issue) => {
+      const path = issue.path && issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+      return `${path}${issue.message}`;
+    });
+    const rest = issues.length - quoted.length;
+    const summary = quoted.join("; ") + (rest > 0 ? ` (+${rest} more)` : "");
+    throw new Error(
+      `Schema validation failed${summary ? ` — ${summary}` : ""}`,
+    );
+  }
+  throw new TypeError(
+    "json(schema): schema must implement safeParse() or parse()",
+  );
+}
+
+/**
+ * Decorate a response promise so `.json(schema)` validates the decoded body.
+ *
+ * Idempotent (a promise is decorated at most once) and defensive: an object
+ * without a `json` method — e.g. a bare `Promise<Response>` from a test double —
+ * passes through untouched. `.track()` is re-wrapped so the schema form survives
+ * `http.get(url).track("GET /users/:id").json(Schema)` even if a runtime ever
+ * returns a fresh promise from `track`.
+ */
+export function attachSchemaJson<P>(promise: P): P {
+  const target = promise as unknown as {
+    json?: (...args: unknown[]) => Promise<unknown>;
+    track?: (pattern: string) => unknown;
+    [SCHEMA_JSON_ATTACHED]?: boolean;
+  } | null;
+
+  if (target == null || typeof target !== "object") return promise;
+  if (target[SCHEMA_JSON_ATTACHED]) return promise;
+  if (typeof target.json !== "function") return promise;
+
+  Object.defineProperty(target, SCHEMA_JSON_ATTACHED, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  const originalJson = target.json.bind(target);
+  target.json = async (schema?: unknown): Promise<unknown> => {
+    const body = await originalJson();
+    if (schema === undefined) return body;
+    return parseWithSchema(body, schema as SchemaLike<unknown>);
+  };
+
+  if (typeof target.track === "function") {
+    const originalTrack = target.track.bind(target);
+    target.track = (pattern: string) => attachSchemaJson(originalTrack(pattern));
+  }
+
+  return promise;
+}
+
+/**
+ * Wrap an `HttpClient` so every response promise it produces (directly or via
+ * `.extend()`) accepts `.json(schema)`.
+ *
+ * `resolve` is a thunk so the `configure()` client can stay lazy — the
+ * underlying client is only materialised when a request is actually made.
+ */
+export function makeSchemaAwareClient(
+  resolve: () => HttpClient,
+): ConfiguredHttpClient {
+  const client: Record<string, unknown> = function (
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ) {
+    return attachSchemaJson(resolve()(url, options));
+  } as unknown as Record<string, unknown>;
+
+  for (const method of HTTP_METHODS) {
+    client[method] = (url: string | URL | Request, options?: HttpRequestOptions) =>
+      attachSchemaJson(resolve()[method](url, options));
+  }
+
+  client["extend"] = (options: HttpRequestOptions) => {
+    // Resolve + extend eagerly (unchanged from the pre-wrapper behaviour: one
+    // `.extend()` call on the underlying client per `.extend()` here), then
+    // hand the concrete instance back through the same wrapper.
+    const extended = resolve().extend(options);
+    return makeSchemaAwareClient(() => extended);
+  };
+
+  return client as unknown as ConfiguredHttpClient;
+}

--- a/packages/sdk/src/configure/schema-json.ts
+++ b/packages/sdk/src/configure/schema-json.ts
@@ -21,15 +21,13 @@
  * existing behaviour (`text()`, `blob()`, `track()`, `await`) is preserved.
  */
 
+import { CONFIGURED_HTTP_CLIENT, SCHEMA_JSON_ATTACHED } from "../types.js";
 import type {
   ConfiguredHttpClient,
   HttpClient,
   HttpRequestOptions,
   SchemaLike,
 } from "../types.js";
-
-/** Marks a response promise whose `json` already accepts a schema. */
-const SCHEMA_JSON_ATTACHED = Symbol.for("glubean.schemaJsonAttached");
 
 /** Max issues quoted when a `safeParse`-only schema rejects the body. */
 const MAX_QUOTED_ISSUES = 3;
@@ -52,7 +50,12 @@ export function parseWithSchema<T>(data: unknown, schema: SchemaLike<T>): T {
     if (result.success) return result.data;
     const issues = result.error?.issues ?? [];
     const quoted = issues.slice(0, MAX_QUOTED_ISSUES).map((issue) => {
-      const path = issue.path && issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+      // `Array#join` throws a TypeError on a symbol segment (a schema keyed by
+      // a symbol property reports one), so stringify each segment first.
+      const path =
+        issue.path && issue.path.length > 0
+          ? `${issue.path.map((segment) => String(segment)).join(".")}: `
+          : "";
       return `${path}${issue.message}`;
     });
     const rest = issues.length - quoted.length;
@@ -128,6 +131,14 @@ export function makeSchemaAwareClient(
     client[method] = (url: string | URL | Request, options?: HttpRequestOptions) =>
       attachSchemaJson(resolve()[method](url, options));
   }
+
+  // Stamp the nominal brand the type declares, so the runtime object really is
+  // what `ConfiguredHttpClient` claims (and a consumer can detect it).
+  Object.defineProperty(client, CONFIGURED_HTTP_CLIENT, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
 
   client["extend"] = (options: HttpRequestOptions) => {
     // Resolve + extend eagerly (unchanged from the pre-wrapper behaviour: one

--- a/packages/sdk/src/configured-http-client.test-d.ts
+++ b/packages/sdk/src/configured-http-client.test-d.ts
@@ -1,0 +1,96 @@
+/**
+ * Type-level tests for the `configure()` HTTP client's schema-aware `.json()`
+ * (issue #32).
+ *
+ * The capability only exists on the client `configure()` builds — `ctx.http` is
+ * built by the runner/engine and its `.json(schema)` falls through to ky's
+ * Standard-Schema path, which rejects a hand-rolled `SchemaLike`. Because the
+ * no-arg `json<T>()` is STRUCTURALLY compatible with `json<T>(schema)`, the
+ * distinction is carried by a nominal brand; these probes pin that a plain
+ * client can NOT masquerade as the configured one.
+ *
+ * No runtime assertions (nothing here is executed). Runs via `tsc --noEmit`.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-unused-expressions */
+
+import { configure } from "./configure.js";
+import type {
+  ConfiguredHttpClient,
+  HttpClient,
+  SchemaLike,
+  TestContext,
+  ValidatingHttpResponsePromise,
+} from "./types.js";
+
+type Exact<A, B> =
+  (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
+
+interface User {
+  id: string;
+  name: string;
+}
+
+declare const ctx: TestContext;
+declare const plainClient: HttpClient;
+declare const UserSchema: SchemaLike<User>;
+
+const configured = configure({}).http;
+
+// ---------------------------------------------------------------------------
+// Test 1: the configured client IS the branded client, and still a plain one
+// ---------------------------------------------------------------------------
+
+const _configuredAssignable: ConfiguredHttpClient = configured;
+const _configuredIsAlsoHttpClient: HttpClient = configured;
+const _extendKeepsBrand: ConfiguredHttpClient = configured.extend({ timeout: 1000 });
+void _configuredAssignable;
+void _configuredIsAlsoHttpClient;
+void _extendKeepsBrand;
+
+// ---------------------------------------------------------------------------
+// Test 2: a plain HttpClient can NOT masquerade as the configured client
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error — ctx.http has no schema-aware json(); calling .json(schema)
+// on it would fall into ky's Standard-Schema path and throw at run time.
+const _ctxHttpIsNotConfigured: ConfiguredHttpClient = ctx.http;
+
+// @ts-expect-error — same for any bare HttpClient (e.g. a hand-built mock).
+const _plainIsNotConfigured: ConfiguredHttpClient = plainClient;
+
+// ---------------------------------------------------------------------------
+// Test 3: the response promise carries the same distinction
+// ---------------------------------------------------------------------------
+
+const _configuredPromise: ValidatingHttpResponsePromise = configured.get("users/1");
+const _trackedPromise: ValidatingHttpResponsePromise = configured
+  .get("users/1")
+  .track("GET /users/:id");
+void _configuredPromise;
+void _trackedPromise;
+
+// @ts-expect-error — a runner-built response promise has no schema form.
+const _plainPromise: ValidatingHttpResponsePromise = ctx.http.get("users/1");
+
+// ---------------------------------------------------------------------------
+// Test 4: return types — schema form is exactly Promise<T>, no-arg unchanged
+// ---------------------------------------------------------------------------
+
+const validated = configured.get("users/1").json(UserSchema);
+const _validatedIsExactlyUser: Exact<typeof validated, Promise<User>> = true;
+void _validatedIsExactlyUser;
+
+const rawBody = configured.get("users/1").json<unknown>();
+const _rawIsUnknown: Exact<typeof rawBody, Promise<unknown>> = true;
+void _rawIsUnknown;
+
+const trackedValidated = configured.get("users/1").track("GET /users/:id").json(UserSchema);
+const _trackedIsExactlyUser: Exact<typeof trackedValidated, Promise<User>> = true;
+void _trackedIsExactlyUser;
+
+// The plain surface is untouched: `ctx.http` still hands back `Promise<T>` from
+// the no-arg form.
+const ctxRaw = ctx.http.get("users/1").json<User>();
+const _ctxRawIsUser: Exact<typeof ctxRaw, Promise<User>> = true;
+void _ctxRawIsUser;

--- a/packages/sdk/src/context-validate.test-d.ts
+++ b/packages/sdk/src/context-validate.test-d.ts
@@ -1,0 +1,96 @@
+/**
+ * Type-level tests for `ctx.validate` severity narrowing (issue #30).
+ *
+ * The runtime aborts on `severity: "fatal"` (runner harness + engine both emit
+ * the failed assertion and then throw), so the call only ever RETURNS on
+ * success. These probes pin that truth into the type system:
+ *
+ *   - `ctx.validate(data, schema, label, { severity: "fatal" })` → exactly `T`
+ *   - every other form (default / "error" / "warn" / widened severity)
+ *     → exactly `T | undefined`
+ *
+ * No runtime assertions. Only type correctness. Runs via `tsc --noEmit`.
+ *
+ * @see packages/runner/src/executor.test.ts "ctx.validate - fatal severity aborts test"
+ * @see packages/runner/src/harness.ts runSchemaValidation (case "fatal" → throw)
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-unused-expressions */
+
+import type { SchemaLike, TestContext, ValidateOptions } from "./types.js";
+
+// Invariant (both-ways) type equality — `A extends B` alone would accept
+// `T` vs `T | undefined` in one direction, which is exactly the bug under test.
+type Exact<A, B> =
+  (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
+
+interface User {
+  id: string;
+  name: string;
+}
+
+// Type-only fixtures (never executed).
+declare const ctx: TestContext;
+declare const body: unknown;
+declare const UserSchema: SchemaLike<User>;
+
+// ---------------------------------------------------------------------------
+// Test 1: `severity: "fatal"` narrows to exactly T (no `| undefined`)
+// ---------------------------------------------------------------------------
+
+const fatalUser = ctx.validate(body, UserSchema, "response body", { severity: "fatal" });
+const _fatalIsExactlyUser: Exact<typeof fatalUser, User> = true;
+const _fatalIsNotOptional: Exact<typeof fatalUser, User | undefined> = false;
+void _fatalIsExactlyUser;
+void _fatalIsNotOptional;
+
+// The narrowed value is usable without `!` / `as User` ceremony.
+const _fatalId: string = fatalUser.id;
+void _fatalId;
+
+// `label` may be omitted by passing `undefined` (a required parameter can't
+// follow an optional one in an overload).
+const fatalNoLabel = ctx.validate(body, UserSchema, undefined, { severity: "fatal" });
+const _fatalNoLabelIsExactlyUser: Exact<typeof fatalNoLabel, User> = true;
+void _fatalNoLabelIsExactlyUser;
+
+// Extra options alongside `severity: "fatal"` still select the narrow overload.
+const fatalWithExtras = ctx.validate(body, UserSchema, "response body", {
+  severity: "fatal",
+} satisfies ValidateOptions & { severity: "fatal" });
+const _fatalWithExtrasIsExactlyUser: Exact<typeof fatalWithExtras, User> = true;
+void _fatalWithExtrasIsExactlyUser;
+
+// ---------------------------------------------------------------------------
+// Test 2: every non-fatal form stays exactly T | undefined
+// ---------------------------------------------------------------------------
+
+const defaultUser = ctx.validate(body, UserSchema, "response body");
+const _defaultIsOptional: Exact<typeof defaultUser, User | undefined> = true;
+const _defaultIsNotNarrowed: Exact<typeof defaultUser, User> = false;
+void _defaultIsOptional;
+void _defaultIsNotNarrowed;
+
+const errorUser = ctx.validate(body, UserSchema, "response body", { severity: "error" });
+const _errorIsOptional: Exact<typeof errorUser, User | undefined> = true;
+void _errorIsOptional;
+
+const warnUser = ctx.validate(body, UserSchema, "response body", { severity: "warn" });
+const _warnIsOptional: Exact<typeof warnUser, User | undefined> = true;
+void _warnIsOptional;
+
+const noOptionsUser = ctx.validate(body, UserSchema);
+const _noOptionsIsOptional: Exact<typeof noOptionsUser, User | undefined> = true;
+void _noOptionsIsOptional;
+
+// A severity the compiler can't pin to the literal "fatal" must NOT narrow —
+// the runtime may or may not abort, so `undefined` stays in the return type.
+declare const dynamicOptions: ValidateOptions;
+const dynamicUser = ctx.validate(body, UserSchema, "response body", dynamicOptions);
+const _dynamicIsOptional: Exact<typeof dynamicUser, User | undefined> = true;
+void _dynamicIsOptional;
+
+declare const maybeFatalOptions: { severity: "fatal" | "warn" };
+const maybeFatalUser = ctx.validate(body, UserSchema, "response body", maybeFatalOptions);
+const _maybeFatalIsOptional: Exact<typeof maybeFatalUser, User | undefined> = true;
+void _maybeFatalIsOptional;

--- a/packages/sdk/src/contract-http/adapter.ts
+++ b/packages/sdk/src/contract-http/adapter.ts
@@ -51,6 +51,7 @@ import type {
   RequestSpec,
 } from "./types.js";
 import { isInboundCase } from "./types.js";
+import { warnOnExampleSchemaDrift } from "./example-check.js";
 import { buildOpenApiPartForHttp } from "./openapi.js";
 import { genericMarkdownPart } from "../contract-artifacts.js";
 import { matchInboundCaseHttp, preflightInboundCaseHttp } from "./inbound-match.js";
@@ -1059,6 +1060,13 @@ function projectHttp(
 function normalizeHttp(
   projection: ContractProjection<HttpPayloadSchemas, HttpContractMeta> & { id: string },
 ): ExtractedContractProjection<HttpSafeSchemas, HttpContractMeta> {
+  // Issue #31: hand-written examples are docs-only — nothing validates them at
+  // run time, so they rot as the schema evolves. `normalize` is the one place
+  // that runs exactly once per contract construction WITH the contract id and
+  // the live (merged) SchemaLike references, so the drift check hangs here.
+  // Advisory only: it warns, never throws, and touches nothing below.
+  warnOnExampleSchemaDrift(projection);
+
   // Record schemas that were DECLARED but failed to project.
   // `schemaToJsonSchema` returns null for BOTH "absent" and "failed", so we
   // disambiguate via the input: a non-null input that yields null means a real

--- a/packages/sdk/src/contract-http/example-check.test.ts
+++ b/packages/sdk/src/contract-http/example-check.test.ts
@@ -411,6 +411,76 @@ test("a nested class instance also disqualifies the site", () => {
   expect(warnings()).toEqual([]);
 });
 
+test("a null-prototype example is skipped, not falsely reported as drift", () => {
+  const seen: unknown[] = [];
+  // Node's structuredClone hands back an object with `Object.prototype`, so a
+  // prototype-sensitive schema accepts the author's value and rejects our copy.
+  const nullProtoSchema: SchemaLike<unknown> = {
+    safeParse(data: unknown) {
+      seen.push(data);
+      return Object.getPrototypeOf(data as object) === null
+        ? { success: true as const, data }
+        : {
+            success: false as const,
+            error: { issues: [{ message: "Expected a null-prototype object" }] },
+          };
+    },
+  };
+
+  const bare = Object.create(null) as Record<string, unknown>;
+  bare["name"] = "Alice";
+
+  const api = contract.http.with("api", { client });
+  api("users.create.null-proto", {
+    endpoint: "POST /users",
+    request: { body: nullProtoSchema, example: bare },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+  expect(seen).toEqual([]); // never handed the lossy copy
+});
+
+test("an example with an accessor or frozen property is skipped", () => {
+  let sawValue = false;
+  const spy: SchemaLike<unknown> = {
+    safeParse() {
+      sawValue = true;
+      return { success: false as const, error: { issues: [{ message: "nope" }] } };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("users.create.getter", {
+    endpoint: "POST /users",
+    // The clone materialises the getter into a plain data property.
+    request: { body: spy, example: { get name() { return "Alice"; } } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+  expect(sawValue).toBe(false);
+  expect(warnings()).toEqual([]);
+
+  api("users.create.frozen", {
+    endpoint: "POST /users",
+    // `Object.freeze` clears writable/configurable; the clone is mutable again.
+    request: { body: spy, example: Object.freeze({ name: 42 }) },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+  expect(sawValue).toBe(false);
+  expect(warnings()).toEqual([]);
+
+  api("users.create.nested-getter", {
+    endpoint: "POST /users",
+    request: {
+      body: spy,
+      example: { meta: { get id() { return "x"; } } },
+    },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+  expect(sawValue).toBe(false);
+  expect(warnings()).toEqual([]);
+});
+
 test("plain JSON examples (objects, arrays, cycles) are still checked", () => {
   const api = contract.http.with("api", { client });
   const cyclic: Record<string, unknown> = { name: 42, items: [1, 2, { deep: true }] };

--- a/packages/sdk/src/contract-http/example-check.test.ts
+++ b/packages/sdk/src/contract-http/example-check.test.ts
@@ -481,6 +481,97 @@ test("an example with an accessor or frozen property is skipped", () => {
   expect(warnings()).toEqual([]);
 });
 
+test("a non-extensible example is skipped, not falsely reported as drift", () => {
+  const seen: unknown[] = [];
+  // The clone is extensible again, so an extensibility-sensitive schema accepts
+  // the author's value and rejects our copy.
+  const extensibilitySchema: SchemaLike<unknown> = {
+    safeParse(data: unknown) {
+      seen.push(data);
+      return Object.isExtensible(data as object)
+        ? {
+            success: false as const,
+            error: { issues: [{ message: "Expected a sealed payload" }] },
+          }
+        : { success: true as const, data };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+
+  api("users.create.prevent-extensions", {
+    endpoint: "POST /users",
+    // preventExtensions leaves every existing property's flags at their
+    // defaults, so only the extensibility test catches it.
+    request: { body: extensibilitySchema, example: Object.preventExtensions({ name: 42 }) },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  api("users.create.empty-frozen", {
+    endpoint: "POST /users",
+    // An EMPTY frozen object has no property for the descriptor rule to catch.
+    request: { body: extensibilitySchema, example: Object.freeze({}) },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  api("users.create.sealed-nested", {
+    endpoint: "POST /users",
+    request: { body: extensibilitySchema, example: { meta: Object.seal({ id: "x" }) } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+  expect(seen).toEqual([]); // never handed the lossy copy
+});
+
+test("an array whose length was made non-writable is skipped", () => {
+  let sawValue = false;
+  const spy: SchemaLike<unknown> = {
+    safeParse() {
+      sawValue = true;
+      return { success: false as const, error: { issues: [{ message: "nope" }] } };
+    },
+  };
+
+  const fixedLength = [1, 2, 3];
+  // Spec fixes only enumerable/configurable on `length`; writable is authorable
+  // and the clone restores it to true.
+  Object.defineProperty(fixedLength, "length", { writable: false });
+
+  const api = contract.http.with("api", { client });
+  api("users.list.fixed-length", {
+    endpoint: "POST /users",
+    request: { body: spy, example: { ids: fixedLength } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(sawValue).toBe(false);
+  expect(warnings()).toEqual([]);
+});
+
+test("ordinary arrays and objects are still checked (guard against over-tightening)", () => {
+  const seen: unknown[] = [];
+  const spy: SchemaLike<unknown> = {
+    safeParse(data: unknown) {
+      seen.push(data);
+      return { success: false as const, error: { issues: [{ message: "nope" }] } };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("users.list.plain-array", {
+    endpoint: "POST /users",
+    // Plain extensible array + nested plain object: default `length`, default
+    // descriptors, extensible — must still be checked.
+    request: { body: spy, example: { ids: [1, 2, 3], meta: { page: 1 } } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(seen).toHaveLength(1);
+  expect(seen[0]).toEqual({ ids: [1, 2, 3], meta: { page: 1 } });
+});
+
 test("plain JSON examples (objects, arrays, cycles) are still checked", () => {
   const api = contract.http.with("api", { client });
   const cyclic: Record<string, unknown> = { name: 42, items: [1, 2, { deep: true }] };

--- a/packages/sdk/src/contract-http/example-check.test.ts
+++ b/packages/sdk/src/contract-http/example-check.test.ts
@@ -272,9 +272,111 @@ test("the same site never warns twice across repeated constructions", () => {
   expect(warnings()).toHaveLength(2); // unchanged — guard held
 });
 
+test("the same id on two scoped surfaces warns once per surface", () => {
+  // `contract.http.with("a")` and `.with("b")` are different surfaces; the same
+  // contract id on both is legal and they are different contracts. The
+  // once-per-site guard must key on the instance too, or the second surface's
+  // drift is silently swallowed.
+  const a = contract.http.with("api-a", { client });
+  const b = contract.http.with("api-b", { client });
+  const spec = {
+    endpoint: "POST /users",
+    request: { body: CreateUser, example: { name: 42 } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  } as const;
+
+  a("users.create.shared-id", { ...spec });
+  b("users.create.shared-id", { ...spec });
+
+  const messages = warnings();
+  expect(messages).toHaveLength(2);
+  expect(messages.some((m) => m.includes(`instance "api-a"`))).toBe(true);
+  expect(messages.some((m) => m.includes(`instance "api-b"`))).toBe(true);
+});
+
+test("symbol segments in an issue path don't swallow the warning", () => {
+  const symbolKey = Symbol("secret");
+  const symbolPathSchema: SchemaLike<unknown> = {
+    safeParse() {
+      return {
+        success: false as const,
+        // `Array#join` throws a TypeError on a symbol segment — pre-fix this
+        // was caught by the outer guard and the warning vanished.
+        error: { issues: [{ message: "Expected string", path: [symbolKey] }] },
+      };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("users.create.symbol-path", {
+    endpoint: "POST /users",
+    request: { body: symbolPathSchema, example: { name: 42 } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(warnings()[0]).toContain("Symbol(secret): Expected string");
+});
+
 // ---------------------------------------------------------------------------
 // The check is advisory: projection output is untouched
 // ---------------------------------------------------------------------------
+
+test("a schema that mutates its input cannot touch the published example", () => {
+  const original = { name: "Alice", nested: { keep: true } };
+  const mutating: SchemaLike<unknown> = {
+    safeParse(data: unknown) {
+      // Hostile (or merely normalizing-in-place) schema: rewrites what it was
+      // handed. If we passed the live reference, this would rewrite the
+      // projection AND the canonicalHash input from inside an advisory check.
+      const obj = data as Record<string, unknown>;
+      obj["injected"] = true;
+      delete obj["name"];
+      (obj["nested"] as Record<string, unknown>)["keep"] = false;
+      return { success: false as const, error: { issues: [{ message: "nope" }] } };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  const c = api("users.create.mutating", {
+    endpoint: "POST /users",
+    request: { body: mutating, example: original },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  // The check ran (so the schema really did get a value)…
+  expect(warnings()).toHaveLength(1);
+  // …but the author's example is byte-for-byte intact, in the live spec and in
+  // the extracted projection that feeds canonicalHash.
+  expect(original).toEqual({ name: "Alice", nested: { keep: true } });
+  expect(c._extracted.schemas?.request?.example).toEqual({
+    name: "Alice",
+    nested: { keep: true },
+  });
+});
+
+test("an un-cloneable example is skipped rather than exposed to the schema", () => {
+  let sawValue = false;
+  const spy: SchemaLike<unknown> = {
+    safeParse() {
+      sawValue = true;
+      return { success: false as const, error: { issues: [{ message: "nope" }] } };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  expect(() =>
+    api("users.create.uncloneable", {
+      endpoint: "POST /users",
+      // A function is not structured-cloneable.
+      request: { body: spy, example: { callback: () => "nope" } },
+      cases: { ok: { description: "creates", expect: { status: 201 } } },
+    }),
+  ).not.toThrow();
+
+  expect(sawValue).toBe(false);
+  expect(warnings()).toEqual([]);
+});
 
 test("a drifting example still lands verbatim in the extracted projection", () => {
   const api = contract.http.with("api", { client });

--- a/packages/sdk/src/contract-http/example-check.test.ts
+++ b/packages/sdk/src/contract-http/example-check.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for the example ↔ schema drift warning (issue #31).
+ *
+ * Scope: the four checkable sites (`request.example`, `request.examples.<k>`,
+ * `cases.<key>.expect.example`, `cases.<key>.expect.examples.<k>`), the
+ * once-per-site guard, and the skip paths (no schema, no example, schema with
+ * neither `safeParse` nor `parse`, schema that throws on its own).
+ *
+ * The warning fires from `adapter.normalize`, i.e. at contract construction —
+ * these tests build real contracts through `contract.http.with(...)`.
+ */
+
+import { test, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+// Import from main index so the HTTP adapter side-effect registration fires.
+import { contract } from "../index.js";
+import type { HttpClient, SchemaLike } from "../types.js";
+import { clearRegistry } from "../internal.js";
+import { clearBootstrapRegistry } from "../bootstrap-registry.js";
+import { __resetExampleWarningsForTesting } from "./example-check.js";
+
+const client = {} as HttpClient;
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  clearRegistry();
+  clearBootstrapRegistry();
+  __resetExampleWarningsForTesting();
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+/** All console.warn messages emitted so far, joined per call. */
+function warnings(): string[] {
+  const calls = warnSpy.mock.calls as unknown as unknown[][];
+  return calls.map((args) => args.map((a) => String(a)).join(" "));
+}
+
+const UserSchema = z.object({ id: z.string(), name: z.string() });
+const CreateUser = z.object({ name: z.string() });
+
+// ---------------------------------------------------------------------------
+// request.example / request.examples
+// ---------------------------------------------------------------------------
+
+test("request.example mismatching request.body warns exactly once", () => {
+  const api = contract.http.with("api", { client });
+  api("users.create.req-bad", {
+    endpoint: "POST /users",
+    request: { body: CreateUser, example: { name: 42 } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(warnings()[0]).toContain(`contract "users.create.req-bad"`);
+  expect(warnings()[0]).toContain("request.example");
+  expect(warnings()[0]).toContain("name:");
+});
+
+test("request.example matching request.body warns nothing", () => {
+  const api = contract.http.with("api", { client });
+  api("users.create.req-ok", {
+    endpoint: "POST /users",
+    request: { body: CreateUser, example: { name: "Alice" } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+});
+
+test("request.examples map: only the drifting entry warns, keyed by name", () => {
+  const api = contract.http.with("api", { client });
+  api("users.create.req-map", {
+    endpoint: "POST /users",
+    request: {
+      body: CreateUser,
+      examples: {
+        happy: { value: { name: "Alice" } },
+        broken: { value: { name: null } },
+      },
+    },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(warnings()[0]).toContain("request.examples.broken");
+  expect(warnings()[0]).not.toContain("request.examples.happy");
+});
+
+test("request.body without any example warns nothing", () => {
+  const api = contract.http.with("api", { client });
+  api("users.create.req-none", {
+    endpoint: "POST /users",
+    request: { body: CreateUser },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+});
+
+test("request.example without a request.body schema warns nothing", () => {
+  const api = contract.http.with("api", { client });
+  api("users.create.req-schemaless", {
+    endpoint: "POST /users",
+    request: { example: { anything: true } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// cases.<key>.expect.example / expect.examples
+// ---------------------------------------------------------------------------
+
+test("case expect.example mismatching expect.schema warns once with the case key", () => {
+  const api = contract.http.with("api", { client });
+  api("users.get.case-bad", {
+    endpoint: "GET /users/:id",
+    cases: {
+      success: {
+        description: "returns a user",
+        expect: {
+          status: 200,
+          schema: UserSchema,
+          example: { id: "u1" }, // missing `name`
+        },
+      },
+    },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(warnings()[0]).toContain(`contract "users.get.case-bad"`);
+  expect(warnings()[0]).toContain(`case "success"`);
+  expect(warnings()[0]).toContain("cases.success.expect.example");
+});
+
+test("case expect.example matching expect.schema warns nothing", () => {
+  const api = contract.http.with("api", { client });
+  api("users.get.case-ok", {
+    endpoint: "GET /users/:id",
+    cases: {
+      success: {
+        description: "returns a user",
+        expect: {
+          status: 200,
+          schema: UserSchema,
+          example: { id: "u1", name: "Alice" },
+        },
+      },
+    },
+  });
+
+  expect(warnings()).toEqual([]);
+});
+
+test("case expect.examples map warns per drifting entry", () => {
+  const api = contract.http.with("api", { client });
+  api("users.get.case-map", {
+    endpoint: "GET /users/:id",
+    cases: {
+      success: {
+        description: "returns a user",
+        expect: {
+          status: 200,
+          schema: UserSchema,
+          examples: {
+            happy: { value: { id: "u1", name: "Alice" } },
+            legacy: { value: { id: "u1", name: 7 } },
+            ancient: { value: {} },
+          },
+        },
+      },
+    },
+  });
+
+  const messages = warnings();
+  expect(messages).toHaveLength(2);
+  expect(messages.some((m) => m.includes("cases.success.expect.examples.legacy"))).toBe(true);
+  expect(messages.some((m) => m.includes("cases.success.expect.examples.ancient"))).toBe(true);
+  expect(messages.some((m) => m.includes("cases.success.expect.examples.happy"))).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// Skip paths — the check must stay silent, and must never throw
+// ---------------------------------------------------------------------------
+
+test("schema exposing neither safeParse nor parse is skipped silently", () => {
+  // Hand-rolled SchemaLike with only a `jsonSchema` companion — nothing to
+  // run the example through.
+  const jsonSchemaOnly: SchemaLike<unknown> = {
+    jsonSchema: { type: "object", properties: { name: { type: "string" } } },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("users.create.no-parser", {
+    endpoint: "POST /users",
+    request: { body: jsonSchemaOnly, example: { totally: "wrong" } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+});
+
+test("parse-only schema drives the fallback path and still warns", () => {
+  const parseOnly: SchemaLike<string> = {
+    parse(data: unknown): string {
+      if (typeof data !== "string") throw new Error("expected a string");
+      return data;
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("users.create.parse-only", {
+    endpoint: "POST /users",
+    request: { body: parseOnly, example: { not: "a string" } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(warnings()[0]).toContain("request.example");
+  expect(warnings()[0]).toContain("expected a string");
+});
+
+test("a schema whose safeParse throws is skipped, and construction survives", () => {
+  const hostile: SchemaLike<unknown> = {
+    safeParse() {
+      throw new Error("schema exploded");
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  expect(() =>
+    api("users.create.hostile", {
+      endpoint: "POST /users",
+      request: { body: hostile, example: { name: "Alice" } },
+      cases: { ok: { description: "creates", expect: { status: 201 } } },
+    }),
+  ).not.toThrow();
+
+  expect(warnings()).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// Once-per-site guard
+// ---------------------------------------------------------------------------
+
+test("the same site never warns twice across repeated constructions", () => {
+  const api = contract.http.with("api", { client });
+  const build = () =>
+    api("users.create.repeat", {
+      endpoint: "POST /users",
+      request: { body: CreateUser, example: { name: 42 } },
+      cases: {
+        success: {
+          description: "creates",
+          expect: { status: 201, schema: UserSchema, example: { id: 1 } },
+        },
+      },
+    });
+
+  build();
+  expect(warnings()).toHaveLength(2); // request.example + cases.success.expect.example
+
+  clearRegistry();
+  clearBootstrapRegistry();
+  build();
+  expect(warnings()).toHaveLength(2); // unchanged — guard held
+});
+
+// ---------------------------------------------------------------------------
+// The check is advisory: projection output is untouched
+// ---------------------------------------------------------------------------
+
+test("a drifting example still lands verbatim in the extracted projection", () => {
+  const api = contract.http.with("api", { client });
+  const c = api("users.create.projection", {
+    endpoint: "POST /users",
+    request: { body: CreateUser, example: { name: 42 } },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(c._extracted.schemas?.request?.example).toEqual({ name: 42 });
+});

--- a/packages/sdk/src/contract-http/example-check.test.ts
+++ b/packages/sdk/src/contract-http/example-check.test.ts
@@ -355,6 +355,108 @@ test("a schema that mutates its input cannot touch the published example", () =>
   });
 });
 
+test("a class-instance example is skipped, not falsely reported as drift", () => {
+  class Money {
+    constructor(readonly amount: number) {}
+    isMoney(): boolean {
+      return true;
+    }
+  }
+  const seen: unknown[] = [];
+  // A schema that accepts the AUTHOR's value: `structuredClone` would hand it a
+  // prototype-less copy, which fails `instanceof` — a warning would be purely an
+  // artifact of our own cloning.
+  const instanceSchema: SchemaLike<Money> = {
+    safeParse(data: unknown) {
+      seen.push(data);
+      return data instanceof Money
+        ? { success: true as const, data: data }
+        : {
+            success: false as const,
+            error: { issues: [{ message: "Expected a Money instance" }] },
+          };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("payments.create.class-example", {
+    endpoint: "POST /payments",
+    request: { body: instanceSchema, example: new Money(42) },
+    cases: { ok: { description: "pays", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toEqual([]);
+  // The schema was never handed the lossy copy in the first place.
+  expect(seen).toEqual([]);
+});
+
+test("a nested class instance also disqualifies the site", () => {
+  class Tag {}
+  let sawValue = false;
+  const spy: SchemaLike<unknown> = {
+    safeParse() {
+      sawValue = true;
+      return { success: false as const, error: { issues: [{ message: "nope" }] } };
+    },
+  };
+
+  const api = contract.http.with("api", { client });
+  api("payments.create.nested-class", {
+    endpoint: "POST /payments",
+    request: { body: spy, example: { meta: { tags: [new Tag()] } } },
+    cases: { ok: { description: "pays", expect: { status: 201 } } },
+  });
+
+  expect(sawValue).toBe(false);
+  expect(warnings()).toEqual([]);
+});
+
+test("plain JSON examples (objects, arrays, cycles) are still checked", () => {
+  const api = contract.http.with("api", { client });
+  const cyclic: Record<string, unknown> = { name: 42, items: [1, 2, { deep: true }] };
+  cyclic["self"] = cyclic; // structuredClone preserves cycles
+
+  api("users.create.plain-shapes", {
+    endpoint: "POST /users",
+    request: { body: CreateUser, example: cyclic },
+    cases: { ok: { description: "creates", expect: { status: 201 } } },
+  });
+
+  expect(warnings()).toHaveLength(1);
+  expect(warnings()[0]).toContain("request.example");
+});
+
+test("dotted case keys and example names can't collide into one site", () => {
+  // Rendered dotted paths collide:
+  //   cases["x"].expect.examples["y.expect.example"]
+  //   cases["x.expect.examples.y"].expect.example
+  // both render `cases.x.expect.examples.y.expect.example`. Keying the guard on
+  // that string made the second site inherit the first's mark and go silent.
+  const api = contract.http.with("api", { client });
+  api("users.get.collision", {
+    endpoint: "GET /users/:id",
+    cases: {
+      x: {
+        description: "named examples",
+        expect: {
+          status: 200,
+          schema: UserSchema,
+          examples: { "y.expect.example": { value: { id: 1 } } },
+        },
+      },
+      "x.expect.examples.y": {
+        description: "single example under a dotted case key",
+        expect: { status: 200, schema: UserSchema, example: { id: 2 } },
+      },
+    },
+  });
+
+  const messages = warnings();
+  expect(messages).toHaveLength(2);
+  expect(messages.filter((m) => m.includes(`case "x"`))).toHaveLength(1);
+  expect(messages.filter((m) => m.includes(`case "x.expect.examples.y"`))).toHaveLength(1);
+});
+
 test("an un-cloneable example is skipped rather than exposed to the schema", () => {
   let sawValue = false;
   const spy: SchemaLike<unknown> = {

--- a/packages/sdk/src/contract-http/example-check.ts
+++ b/packages/sdk/src/contract-http/example-check.ts
@@ -106,6 +106,13 @@ function summarizeThrown(err: unknown): string {
  *   materialises every accessor into a plain data property and drops the flags,
  *   so a schema that reads a getter twice, or checks `Object.isFrozen`, sees a
  *   different object than the author wrote.
+ * - **Non-extensible objects** (`Object.preventExtensions` / `seal` / `freeze`,
+ *   including an EMPTY frozen object that has no property for the descriptor
+ *   rule to catch) — the clone is extensible again, so an
+ *   `Object.isExtensible`-sensitive schema splits the two apart.
+ * - **Arrays whose `length` was made non-writable** — spec fixes only
+ *   `enumerable`/`configurable` on `length`; `writable: false` is authorable and
+ *   the clone restores it to `true`.
  * - **`Date` / `RegExp`** — `structuredClone` *does* preserve these two, so
  *   allowing them would be sound. They are excluded anyway to keep ONE rule
  *   ("the example is a JSON document") that matches what an example actually
@@ -140,6 +147,12 @@ function isPlainJsonShape(value: unknown, seen: WeakSet<object>): boolean {
   if (seen.has(object)) return true;
   seen.add(object);
 
+  // `Object.preventExtensions` / `seal` / `freeze` are all restored to a plain
+  // extensible object by the clone. `freeze`/`seal` usually trip the descriptor
+  // check below, but an EMPTY frozen object (or a merely non-extensible one)
+  // has no property to catch it — so test extensibility directly.
+  if (!Object.isExtensible(object)) return false;
+
   if (Object.getOwnPropertySymbols(object).length > 0) return false;
 
   const prototype = Object.getPrototypeOf(object) as unknown;
@@ -150,8 +163,13 @@ function isPlainJsonShape(value: unknown, seen: WeakSet<object>): boolean {
     // Own props beyond the indices + `length` (an "expando" or sparse array)
     // are dropped or reshaped by the clone.
     if (Object.getOwnPropertyNames(object).length !== object.length + 1) return false;
-    // `length` itself is non-enumerable/non-configurable by spec on EVERY
-    // array, so it is not evidence of tampering — check the indices only.
+    // Only `enumerable: false` + `configurable: false` are spec-fixed for EVERY
+    // array's `length`, so those two aren't evidence of tampering — but
+    // `writable` CAN be turned off (`Object.defineProperty(arr, "length",
+    // { writable: false })`), and the clone hands back a writable one. Demand
+    // the default there.
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(object, "length");
+    if (!lengthDescriptor || lengthDescriptor.writable !== true) return false;
     for (let index = 0; index < object.length; index += 1) {
       if (!isDefaultDataProperty(object, String(index))) return false;
     }

--- a/packages/sdk/src/contract-http/example-check.ts
+++ b/packages/sdk/src/contract-http/example-check.ts
@@ -1,0 +1,205 @@
+/**
+ * @module contract-http/example-check
+ *
+ * Build-time drift check between hand-written examples and the schemas they
+ * sit beside (issue #31).
+ *
+ * `request.example` / `request.examples` and a case's `expect.example` /
+ * `expect.examples` are documentation-only: nothing validates them at run time,
+ * so they rot silently as the schema evolves and the OpenAPI/Markdown
+ * projections keep publishing a payload the API would reject.
+ *
+ * This module runs once per contract construction (called from the HTTP
+ * adapter's `normalize`) and emits ONE `console.warn` per drifting site. It is
+ * strictly advisory:
+ *
+ * - never throws (a schema that misbehaves is silently skipped),
+ * - never touches the projection output, `canonicalHash` inputs, or execution,
+ * - never warns twice for the same `id` + site path, even if the module is
+ *   re-imported and the contract re-constructed.
+ *
+ * HTTP only for now — GraphQL / gRPC examples are out of scope.
+ */
+
+import type { ContractProjection } from "../contract-types.js";
+import type { SchemaLike } from "../types.js";
+import type {
+  ContractExample,
+  HttpContractMeta,
+  HttpPayloadSchemas,
+} from "./types.js";
+
+/** Sites already warned about, keyed by `contractId` + site path. */
+const warnedSites = new Set<string>();
+
+/** Max issues quoted in a warning before it collapses to "(+N more)". */
+const MAX_QUOTED_ISSUES = 3;
+
+/** Max characters of a thrown-error message quoted in a warning. */
+const MAX_MESSAGE_CHARS = 200;
+
+/**
+ * Clear the "already warned" guard. Test-only — production code constructs a
+ * contract once per process, so the guard is never reset at run time.
+ * @internal
+ */
+export function __resetExampleWarningsForTesting(): void {
+  warnedSites.clear();
+}
+
+type ExampleCheck =
+  /** Example parsed cleanly, or there was nothing checkable here. */
+  | { status: "ok" }
+  /** Example is present and the schema rejected it. */
+  | { status: "mismatch"; summary: string };
+
+interface SchemaIssueLike {
+  message?: string;
+  path?: ReadonlyArray<PropertyKey>;
+}
+
+function summarizeIssues(issues: ReadonlyArray<SchemaIssueLike>): string {
+  const quoted = issues.slice(0, MAX_QUOTED_ISSUES).map((issue) => {
+    const path = issue.path && issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+    return `${path}${issue.message ?? "invalid"}`;
+  });
+  const rest = issues.length - quoted.length;
+  return quoted.join("; ") + (rest > 0 ? ` (+${rest} more)` : "");
+}
+
+function summarizeThrown(err: unknown): string {
+  const issues = (err as { issues?: unknown } | null)?.issues;
+  if (Array.isArray(issues) && issues.length > 0) {
+    return summarizeIssues(issues as ReadonlyArray<SchemaIssueLike>);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return message.length > MAX_MESSAGE_CHARS
+    ? `${message.slice(0, MAX_MESSAGE_CHARS)}…`
+    : message;
+}
+
+/**
+ * Run the schema against the example. `safeParse` is preferred, `parse` is the
+ * fallback; a schema exposing neither (e.g. a hand-rolled `jsonSchema`-only
+ * `SchemaLike`) is skipped silently, as is any schema that blows up on its own.
+ */
+function checkExample(schema: SchemaLike<unknown>, value: unknown): ExampleCheck {
+  try {
+    if (typeof schema.safeParse === "function") {
+      const result = schema.safeParse(value);
+      if (result.success) return { status: "ok" };
+      return { status: "mismatch", summary: summarizeIssues(result.error?.issues ?? []) };
+    }
+    if (typeof schema.parse === "function") {
+      try {
+        schema.parse(value);
+        return { status: "ok" };
+      } catch (err) {
+        return { status: "mismatch", summary: summarizeThrown(err) };
+      }
+    }
+  } catch {
+    // The schema itself misbehaved (a safeParse that throws, an exotic
+    // validator). That is not the author's example problem — stay quiet
+    // rather than blame the wrong artifact.
+    return { status: "ok" };
+  }
+  // Neither safeParse nor parse — nothing to check against.
+  return { status: "ok" };
+}
+
+function checkSite(
+  contractId: string,
+  caseKey: string | undefined,
+  sitePath: string,
+  schema: SchemaLike<unknown> | undefined,
+  value: unknown,
+): void {
+  // Both a schema and an example must be present for the site to be checkable.
+  // A schema may be a callable (some libraries hand back a function carrying
+  // `parse`/`safeParse`), so accept "function" alongside "object".
+  if (schema == null) return;
+  if (typeof schema !== "object" && typeof schema !== "function") return;
+  if (value === undefined) return;
+
+  // NUL separator so no id/path pair can collide with another.
+  const guardKey = `${contractId}\u0000${sitePath}`;
+  if (warnedSites.has(guardKey)) return;
+
+  const result = checkExample(schema, value);
+  if (result.status === "ok") return;
+
+  warnedSites.add(guardKey);
+  const where = caseKey === undefined ? "" : ` case "${caseKey}"`;
+  console.warn(
+    `[glubean] contract "${contractId}"${where}: ${sitePath} does not match its ` +
+      `schema — ${result.summary} (examples are documentation-only; update the ` +
+      `example or the schema)`,
+  );
+}
+
+function checkExamplesMap(
+  contractId: string,
+  caseKey: string | undefined,
+  basePath: string,
+  schema: SchemaLike<unknown> | undefined,
+  examples: Record<string, ContractExample<unknown>> | undefined,
+): void {
+  if (!examples || typeof examples !== "object") return;
+  for (const [name, example] of Object.entries(examples)) {
+    if (!example || typeof example !== "object") continue;
+    checkSite(contractId, caseKey, `${basePath}.${name}`, schema, example.value);
+  }
+}
+
+/**
+ * Warn about every example that no longer matches the schema next to it.
+ *
+ * Checked sites:
+ * - `request.example` and `request.examples.<name>` against `request.body`
+ * - `cases.<key>.expect.example` and `cases.<key>.expect.examples.<name>`
+ *   against that case's `expect.schema`
+ *
+ * Inbound cases carry no `expect.schema`/response examples, so they contribute
+ * no sites.
+ */
+export function warnOnExampleSchemaDrift(
+  projection: ContractProjection<HttpPayloadSchemas, HttpContractMeta> & { id: string },
+): void {
+  try {
+    const contractId = projection.id;
+
+    const request = projection.schemas?.request;
+    if (request) {
+      checkSite(contractId, undefined, "request.example", request.body, request.example);
+      checkExamplesMap(
+        contractId,
+        undefined,
+        "request.examples",
+        request.body,
+        request.examples,
+      );
+    }
+
+    for (const projCase of projection.cases ?? []) {
+      const response = projCase.schemas?.response;
+      if (!response) continue;
+      checkSite(
+        contractId,
+        projCase.key,
+        `cases.${projCase.key}.expect.example`,
+        response.body,
+        response.example,
+      );
+      checkExamplesMap(
+        contractId,
+        projCase.key,
+        `cases.${projCase.key}.expect.examples`,
+        response.body,
+        response.examples,
+      );
+    }
+  } catch {
+    // A docs-quality hint must never break contract construction.
+  }
+}

--- a/packages/sdk/src/contract-http/example-check.ts
+++ b/packages/sdk/src/contract-http/example-check.ts
@@ -60,7 +60,13 @@ interface SchemaIssueLike {
 
 function summarizeIssues(issues: ReadonlyArray<SchemaIssueLike>): string {
   const quoted = issues.slice(0, MAX_QUOTED_ISSUES).map((issue) => {
-    const path = issue.path && issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+    // `Array#join` throws a TypeError on a symbol segment (a schema keyed by a
+    // symbol property reports one). The outer catch would swallow that and the
+    // drift warning would vanish — stringify each segment first.
+    const path =
+      issue.path && issue.path.length > 0
+        ? `${issue.path.map((segment) => String(segment)).join(".")}: `
+        : "";
     return `${path}${issue.message ?? "invalid"}`;
   });
   const rest = issues.length - quoted.length;
@@ -82,17 +88,31 @@ function summarizeThrown(err: unknown): string {
  * Run the schema against the example. `safeParse` is preferred, `parse` is the
  * fallback; a schema exposing neither (e.g. a hand-rolled `jsonSchema`-only
  * `SchemaLike`) is skipped silently, as is any schema that blows up on its own.
+ *
+ * The example is deep-cloned first: the value handed to the schema is the SAME
+ * object the projection publishes (and `canonicalHash` covers), and a schema
+ * that normalizes in place (or a `parse` that mutates its input) would rewrite
+ * the author's artifact from inside an advisory check. A value that can't be
+ * cloned (functions, class instances, streams) is skipped rather than exposed.
  */
 function checkExample(schema: SchemaLike<unknown>, value: unknown): ExampleCheck {
+  let isolated: unknown;
+  try {
+    isolated = structuredClone(value);
+  } catch {
+    // Not cloneable — refuse to hand the live reference to a user schema.
+    return { status: "ok" };
+  }
+
   try {
     if (typeof schema.safeParse === "function") {
-      const result = schema.safeParse(value);
+      const result = schema.safeParse(isolated);
       if (result.success) return { status: "ok" };
       return { status: "mismatch", summary: summarizeIssues(result.error?.issues ?? []) };
     }
     if (typeof schema.parse === "function") {
       try {
-        schema.parse(value);
+        schema.parse(isolated);
         return { status: "ok" };
       } catch (err) {
         return { status: "mismatch", summary: summarizeThrown(err) };
@@ -108,8 +128,19 @@ function checkExample(schema: SchemaLike<unknown>, value: unknown): ExampleCheck
   return { status: "ok" };
 }
 
+/**
+ * Identity of the contract a site belongs to. The id ALONE is not unique: the
+ * same id may legally be authored on two scoped surfaces
+ * (`contract.http.with("api-a")` / `.with("api-b")`), and they are different
+ * contracts with different schemas — so the once-per-site guard keys on both.
+ */
+interface ContractSite {
+  contractId: string;
+  instanceName: string | undefined;
+}
+
 function checkSite(
-  contractId: string,
+  site: ContractSite,
   caseKey: string | undefined,
   sitePath: string,
   schema: SchemaLike<unknown> | undefined,
@@ -122,24 +153,26 @@ function checkSite(
   if (typeof schema !== "object" && typeof schema !== "function") return;
   if (value === undefined) return;
 
-  // NUL separator so no id/path pair can collide with another.
-  const guardKey = `${contractId}\u0000${sitePath}`;
+  // JSON array key: injective, so no instance/id/path triple can collide.
+  const guardKey = JSON.stringify([site.instanceName ?? "", site.contractId, sitePath]);
   if (warnedSites.has(guardKey)) return;
 
   const result = checkExample(schema, value);
   if (result.status === "ok") return;
 
   warnedSites.add(guardKey);
+  const instance =
+    site.instanceName === undefined ? "" : ` (instance "${site.instanceName}")`;
   const where = caseKey === undefined ? "" : ` case "${caseKey}"`;
   console.warn(
-    `[glubean] contract "${contractId}"${where}: ${sitePath} does not match its ` +
-      `schema — ${result.summary} (examples are documentation-only; update the ` +
-      `example or the schema)`,
+    `[glubean] contract "${site.contractId}"${instance}${where}: ${sitePath} does ` +
+      `not match its schema — ${result.summary} (examples are documentation-only; ` +
+      `update the example or the schema)`,
   );
 }
 
 function checkExamplesMap(
-  contractId: string,
+  site: ContractSite,
   caseKey: string | undefined,
   basePath: string,
   schema: SchemaLike<unknown> | undefined,
@@ -148,7 +181,7 @@ function checkExamplesMap(
   if (!examples || typeof examples !== "object") return;
   for (const [name, example] of Object.entries(examples)) {
     if (!example || typeof example !== "object") continue;
-    checkSite(contractId, caseKey, `${basePath}.${name}`, schema, example.value);
+    checkSite(site, caseKey, `${basePath}.${name}`, schema, example.value);
   }
 }
 
@@ -167,13 +200,16 @@ export function warnOnExampleSchemaDrift(
   projection: ContractProjection<HttpPayloadSchemas, HttpContractMeta> & { id: string },
 ): void {
   try {
-    const contractId = projection.id;
+    const site: ContractSite = {
+      contractId: projection.id,
+      instanceName: projection.instanceName,
+    };
 
     const request = projection.schemas?.request;
     if (request) {
-      checkSite(contractId, undefined, "request.example", request.body, request.example);
+      checkSite(site, undefined, "request.example", request.body, request.example);
       checkExamplesMap(
-        contractId,
+        site,
         undefined,
         "request.examples",
         request.body,
@@ -185,14 +221,14 @@ export function warnOnExampleSchemaDrift(
       const response = projCase.schemas?.response;
       if (!response) continue;
       checkSite(
-        contractId,
+        site,
         projCase.key,
         `cases.${projCase.key}.expect.example`,
         response.body,
         response.example,
       );
       checkExamplesMap(
-        contractId,
+        site,
         projCase.key,
         `cases.${projCase.key}.expect.examples`,
         response.body,

--- a/packages/sdk/src/contract-http/example-check.ts
+++ b/packages/sdk/src/contract-http/example-check.ts
@@ -88,13 +88,24 @@ function summarizeThrown(err: unknown): string {
  * Is `value` a plain JSON shape, i.e. one that `structuredClone` reproduces
  * INDISTINGUISHABLY as far as a schema can tell?
  *
- * Only primitives, plain objects (`Object.prototype` or null prototype) and
- * plain arrays qualify. Everything else is rejected:
+ * Qualifying shapes: primitives, objects whose prototype is exactly
+ * `Object.prototype`, and arrays whose prototype is exactly `Array.prototype` —
+ * in both cases carrying ONLY default data properties (enumerable + writable +
+ * configurable). Everything else is rejected:
  *
  * - **Class instances** — `structuredClone` returns a plain object, so a schema
  *   doing `instanceof Foo` (or reading a prototype method) rejects the clone
  *   while the author's real example would pass. That is a FALSE drift warning,
  *   the one failure mode this check must never produce.
+ * - **`Object.create(null)` objects** — same class of loss in the other
+ *   direction: Node's `structuredClone` hands back an object with
+ *   `Object.prototype`, so a schema asserting a null prototype (or relying on
+ *   the absence of inherited keys) accepts the author's value and rejects ours.
+ * - **Accessor properties, and data properties with non-default flags**
+ *   (a getter/setter, `Object.freeze`, `writable: false`, …) — the clone
+ *   materialises every accessor into a plain data property and drops the flags,
+ *   so a schema that reads a getter twice, or checks `Object.isFrozen`, sees a
+ *   different object than the author wrote.
  * - **`Date` / `RegExp`** — `structuredClone` *does* preserve these two, so
  *   allowing them would be sound. They are excluded anyway to keep ONE rule
  *   ("the example is a JSON document") that matches what an example actually
@@ -136,18 +147,43 @@ function isPlainJsonShape(value: unknown, seen: WeakSet<object>): boolean {
     // An Array SUBCLASS clones down to a plain array — same identity loss as a
     // class instance.
     if (prototype !== Array.prototype) return false;
-    // Own props beyond the indices + `length` (an "expando" array) are dropped
-    // or reshaped by the clone.
+    // Own props beyond the indices + `length` (an "expando" or sparse array)
+    // are dropped or reshaped by the clone.
     if (Object.getOwnPropertyNames(object).length !== object.length + 1) return false;
+    // `length` itself is non-enumerable/non-configurable by spec on EVERY
+    // array, so it is not evidence of tampering — check the indices only.
+    for (let index = 0; index < object.length; index += 1) {
+      if (!isDefaultDataProperty(object, String(index))) return false;
+    }
     return object.every((item) => isPlainJsonShape(item, seen));
   }
 
-  if (prototype !== Object.prototype && prototype !== null) return false;
+  // `Object.create(null)` is NOT allowed: the clone comes back with
+  // `Object.prototype`, which a prototype-sensitive schema can tell apart.
+  if (prototype !== Object.prototype) return false;
   // Non-enumerable own properties don't survive the clone.
-  if (Object.getOwnPropertyNames(object).length !== Object.keys(object).length) {
-    return false;
+  const names = Object.getOwnPropertyNames(object);
+  if (names.length !== Object.keys(object).length) return false;
+  for (const name of names) {
+    if (!isDefaultDataProperty(object, name)) return false;
   }
   return Object.values(object).every((item) => isPlainJsonShape(item, seen));
+}
+
+/**
+ * Is `key` an own property the clone reproduces exactly — a data property with
+ * the three default flags? An accessor is materialised into a data property by
+ * the clone, and a non-writable / non-configurable flag is simply dropped.
+ */
+function isDefaultDataProperty(object: object, key: string): boolean {
+  const descriptor = Object.getOwnPropertyDescriptor(object, key);
+  if (!descriptor) return false;
+  if (!("value" in descriptor)) return false; // getter / setter
+  return (
+    descriptor.enumerable === true &&
+    descriptor.writable === true &&
+    descriptor.configurable === true
+  );
 }
 
 /**

--- a/packages/sdk/src/contract-http/example-check.ts
+++ b/packages/sdk/src/contract-http/example-check.ts
@@ -85,6 +85,72 @@ function summarizeThrown(err: unknown): string {
 }
 
 /**
+ * Is `value` a plain JSON shape, i.e. one that `structuredClone` reproduces
+ * INDISTINGUISHABLY as far as a schema can tell?
+ *
+ * Only primitives, plain objects (`Object.prototype` or null prototype) and
+ * plain arrays qualify. Everything else is rejected:
+ *
+ * - **Class instances** — `structuredClone` returns a plain object, so a schema
+ *   doing `instanceof Foo` (or reading a prototype method) rejects the clone
+ *   while the author's real example would pass. That is a FALSE drift warning,
+ *   the one failure mode this check must never produce.
+ * - **`Date` / `RegExp`** — `structuredClone` *does* preserve these two, so
+ *   allowing them would be sound. They are excluded anyway to keep ONE rule
+ *   ("the example is a JSON document") that matches what an example actually
+ *   is: a payload the projection publishes as JSON, where a `Date` cannot
+ *   survive serialization. Relaxing this later is a one-line change.
+ * - **`Map` / `Set` / typed arrays** — cloneable, but outside that same JSON
+ *   vocabulary.
+ * - **Functions / symbols** — not cloneable at all.
+ * - **Symbol-keyed or non-enumerable own properties** — silently dropped by
+ *   `structuredClone`, so a schema reading them would see a different value.
+ *
+ * Skipping is always safe: this whole module is advisory, and a missed warning
+ * costs far less than a wrong one.
+ */
+function isPlainJsonShape(value: unknown, seen: WeakSet<object>): boolean {
+  if (value === null) return true;
+  const kind = typeof value;
+  if (
+    kind === "string" ||
+    kind === "number" ||
+    kind === "boolean" ||
+    kind === "undefined" ||
+    kind === "bigint"
+  ) {
+    return true;
+  }
+  if (kind !== "object") return false; // function, symbol
+
+  const object = value as object;
+  // A cycle is fine — `structuredClone` preserves cycles, and the node itself
+  // was already checked on the way down.
+  if (seen.has(object)) return true;
+  seen.add(object);
+
+  if (Object.getOwnPropertySymbols(object).length > 0) return false;
+
+  const prototype = Object.getPrototypeOf(object) as unknown;
+  if (Array.isArray(object)) {
+    // An Array SUBCLASS clones down to a plain array — same identity loss as a
+    // class instance.
+    if (prototype !== Array.prototype) return false;
+    // Own props beyond the indices + `length` (an "expando" array) are dropped
+    // or reshaped by the clone.
+    if (Object.getOwnPropertyNames(object).length !== object.length + 1) return false;
+    return object.every((item) => isPlainJsonShape(item, seen));
+  }
+
+  if (prototype !== Object.prototype && prototype !== null) return false;
+  // Non-enumerable own properties don't survive the clone.
+  if (Object.getOwnPropertyNames(object).length !== Object.keys(object).length) {
+    return false;
+  }
+  return Object.values(object).every((item) => isPlainJsonShape(item, seen));
+}
+
+/**
  * Run the schema against the example. `safeParse` is preferred, `parse` is the
  * fallback; a schema exposing neither (e.g. a hand-rolled `jsonSchema`-only
  * `SchemaLike`) is skipped silently, as is any schema that blows up on its own.
@@ -92,15 +158,18 @@ function summarizeThrown(err: unknown): string {
  * The example is deep-cloned first: the value handed to the schema is the SAME
  * object the projection publishes (and `canonicalHash` covers), and a schema
  * that normalizes in place (or a `parse` that mutates its input) would rewrite
- * the author's artifact from inside an advisory check. A value that can't be
- * cloned (functions, class instances, streams) is skipped rather than exposed.
+ * the author's artifact from inside an advisory check. A value the clone can't
+ * reproduce faithfully ({@link isPlainJsonShape}) is skipped rather than either
+ * exposed live or misjudged through a lossy copy.
  */
 function checkExample(schema: SchemaLike<unknown>, value: unknown): ExampleCheck {
   let isolated: unknown;
   try {
+    if (!isPlainJsonShape(value, new WeakSet<object>())) return { status: "ok" };
     isolated = structuredClone(value);
   } catch {
-    // Not cloneable — refuse to hand the live reference to a user schema.
+    // Not cloneable, or a getter/proxy threw while we inspected the shape —
+    // refuse to hand the live reference to a user schema.
     return { status: "ok" };
   }
 
@@ -139,10 +208,37 @@ interface ContractSite {
   instanceName: string | undefined;
 }
 
+/**
+ * Structured identity of one checkable site.
+ *
+ * Each authored name (case key, named-example key) is its OWN tuple element, so
+ * the identity is injective by construction. The rendered dotted path is not:
+ * a case key or example name may itself contain dots, and then e.g.
+ * `cases["x"].expect.examples["y.expect.example"]` and
+ * `cases["x.expect.examples.y"].expect.example` render the SAME string —
+ * keying on that string made the second site inherit the first one's
+ * "already warned" mark and vanish. The dotted form is now display-only.
+ */
+type SiteId =
+  | readonly ["request", "example"]
+  | readonly ["request", "examples", string]
+  | readonly ["case", string, "example"]
+  | readonly ["case", string, "examples", string];
+
+/** The author-facing dotted path for a site — for the warning text only. */
+function renderSitePath(siteId: SiteId): string {
+  if (siteId[0] === "request") {
+    return siteId.length === 2 ? "request.example" : `request.examples.${siteId[2]}`;
+  }
+  const caseKey = siteId[1];
+  return siteId.length === 3
+    ? `cases.${caseKey}.expect.example`
+    : `cases.${caseKey}.expect.examples.${siteId[3]}`;
+}
+
 function checkSite(
   site: ContractSite,
-  caseKey: string | undefined,
-  sitePath: string,
+  siteId: SiteId,
   schema: SchemaLike<unknown> | undefined,
   value: unknown,
 ): void {
@@ -153,8 +249,9 @@ function checkSite(
   if (typeof schema !== "object" && typeof schema !== "function") return;
   if (value === undefined) return;
 
-  // JSON array key: injective, so no instance/id/path triple can collide.
-  const guardKey = JSON.stringify([site.instanceName ?? "", site.contractId, sitePath]);
+  // JSON array key over the STRUCTURED parts: injective, so no
+  // instance/id/case/example combination can collide with another.
+  const guardKey = JSON.stringify([site.instanceName ?? "", site.contractId, ...siteId]);
   if (warnedSites.has(guardKey)) return;
 
   const result = checkExample(schema, value);
@@ -163,25 +260,28 @@ function checkSite(
   warnedSites.add(guardKey);
   const instance =
     site.instanceName === undefined ? "" : ` (instance "${site.instanceName}")`;
-  const where = caseKey === undefined ? "" : ` case "${caseKey}"`;
+  const where = siteId[0] === "case" ? ` case "${siteId[1]}"` : "";
   console.warn(
-    `[glubean] contract "${site.contractId}"${instance}${where}: ${sitePath} does ` +
-      `not match its schema — ${result.summary} (examples are documentation-only; ` +
-      `update the example or the schema)`,
+    `[glubean] contract "${site.contractId}"${instance}${where}: ` +
+      `${renderSitePath(siteId)} does not match its schema — ${result.summary} ` +
+      `(examples are documentation-only; update the example or the schema)`,
   );
 }
 
 function checkExamplesMap(
   site: ContractSite,
   caseKey: string | undefined,
-  basePath: string,
   schema: SchemaLike<unknown> | undefined,
   examples: Record<string, ContractExample<unknown>> | undefined,
 ): void {
   if (!examples || typeof examples !== "object") return;
   for (const [name, example] of Object.entries(examples)) {
     if (!example || typeof example !== "object") continue;
-    checkSite(site, caseKey, `${basePath}.${name}`, schema, example.value);
+    const siteId: SiteId =
+      caseKey === undefined
+        ? (["request", "examples", name] as const)
+        : (["case", caseKey, "examples", name] as const);
+    checkSite(site, siteId, schema, example.value);
   }
 }
 
@@ -207,14 +307,8 @@ export function warnOnExampleSchemaDrift(
 
     const request = projection.schemas?.request;
     if (request) {
-      checkSite(site, undefined, "request.example", request.body, request.example);
-      checkExamplesMap(
-        site,
-        undefined,
-        "request.examples",
-        request.body,
-        request.examples,
-      );
+      checkSite(site, ["request", "example"], request.body, request.example);
+      checkExamplesMap(site, undefined, request.body, request.examples);
     }
 
     for (const projCase of projection.cases ?? []) {
@@ -222,18 +316,11 @@ export function warnOnExampleSchemaDrift(
       if (!response) continue;
       checkSite(
         site,
-        projCase.key,
-        `cases.${projCase.key}.expect.example`,
+        ["case", projCase.key, "example"],
         response.body,
         response.example,
       );
-      checkExamplesMap(
-        site,
-        projCase.key,
-        `cases.${projCase.key}.expect.examples`,
-        response.body,
-        response.examples,
-      );
+      checkExamplesMap(site, projCase.key, response.body, response.examples);
     }
   } catch {
     // A docs-quality hint must never break contract construction.

--- a/packages/sdk/src/poll-primitives.test.ts
+++ b/packages/sdk/src/poll-primitives.test.ts
@@ -122,4 +122,29 @@ describe("quarantinedCtx", () => {
     expect(() => q.validate({ a: 1 }, schema, "body", { severity: "fatal" })).toThrow(/fatal validation/);
     expect(q.hasFailure()).toBe(true);
   });
+
+  test("validate with severity:fatal throws for a schema with NO parser (can't prove success)", () => {
+    const real = { validate: () => {}, log: () => {} } as unknown as TestContext;
+    const q = quarantinedCtx(real);
+    // GLU-90 shape: a hand-rolled SchemaLike carrying only a `jsonSchema`
+    // companion — no safeParse, no parse. Nothing can validate the data, so a
+    // fatal validation must abort rather than return an unproven `undefined`
+    // (the fatal overload's narrowed `T` return type depends on it).
+    const jsonSchemaOnly = { jsonSchema: { type: "object" } } as any;
+    expect(() =>
+      q.validate({ a: 1 }, jsonSchemaOnly, "body", { severity: "fatal" }),
+    ).toThrow(/fatal validation/);
+    expect(q.hasFailure()).toBe(true);
+  });
+
+  test("validate with a NO-parser schema counts as a failed validation at non-fatal severity", () => {
+    const real = { validate: () => {}, log: () => {} } as unknown as TestContext;
+    const q = quarantinedCtx(real);
+    const jsonSchemaOnly = { jsonSchema: { type: "object" } } as any;
+    // Return value is unchanged (`undefined`, matching `T | undefined`), but the
+    // attempt must be recorded as failing — parity with the real ctx, which
+    // routes "Schema has neither safeParse nor parse method" to assert(false).
+    expect(q.validate({ a: 1 }, jsonSchemaOnly, "body")).toBeUndefined();
+    expect(q.hasFailure()).toBe(true);
+  });
 });

--- a/packages/sdk/src/poll-primitives.ts
+++ b/packages/sdk/src/poll-primitives.ts
@@ -139,6 +139,15 @@ export function quarantinedCtx(real: TestContext): QuarantinedContext {
         } catch {
           ok = false;
         }
+      } else {
+        // Neither safeParse nor parse (a `jsonSchema`-only SchemaLike, GLU-90):
+        // nothing can prove the data valid, so this is a FAILED validation —
+        // exactly what the real ctx records ("Schema has neither safeParse nor
+        // parse method", harness.ts / engine.ts / workflow execute.ts all route
+        // it through the failure branch). Leaving `ok = true` here made a
+        // `severity: "fatal"` call return `undefined` without aborting, which
+        // the narrowed `T` return type promises can never happen.
+        ok = false;
       }
       recordAssert(ok);
       buffer.push((t) =>

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1246,9 +1246,11 @@ export interface ConfigureResult<
    * Pre-configured HTTP client. Lazily constructed from `ctx.http.extend()`
    * on first use during test execution. Inherits auto-tracing and auto-metrics.
    *
-   * Supports further `.extend()` for per-test customization.
+   * Supports further `.extend()` for per-test customization, and a schema-aware
+   * `.json(schema)` that returns the validated value
+   * ({@link ValidatingHttpResponsePromise}).
    */
-  http: HttpClient;
+  http: ConfiguredHttpClient;
 }
 
 // =============================================================================
@@ -1775,6 +1777,91 @@ export interface HttpClient {
    * ```
    */
   extend(options: HttpRequestOptions): HttpClient;
+}
+
+/**
+ * Response promise returned by the `configure()` HTTP client. Same surface as
+ * {@link HttpResponsePromise} plus a schema-aware `.json(schema)` shortcut.
+ *
+ * `.json(schema)` decodes the body and hands it to the schema, returning the
+ * VALIDATED value typed from the schema — the runtime owns the recurring
+ * `const raw = await http.get(url).json<unknown>(); const x = S.parse(raw);`
+ * two-liner. Failure throws whatever the schema throws (`parse`), or an `Error`
+ * carrying the issue summary for a `safeParse`-only schema.
+ *
+ * Only the `configure()` client implements this — `ctx.http` is provided by the
+ * runner/engine and keeps the plain {@link HttpResponsePromise} surface.
+ *
+ * @example Validate in one step
+ * ```ts
+ * const { http } = configure({ http: { prefixUrl: "{{BASE_URL}}" } });
+ * const user = await http.get("users/1").json(UserSchema); // typed as User
+ * ```
+ *
+ * @example Chained after `.track()`
+ * ```ts
+ * const user = await http.get(`users/${id}`).track("GET /users/:id").json(UserSchema);
+ * ```
+ */
+export interface ValidatingHttpResponsePromise extends HttpResponsePromise {
+  /** Parse response body as JSON (unvalidated — `T` is an author assertion). */
+  json<T = unknown>(): Promise<T>;
+  /** Parse response body as JSON, then validate it with `schema`. */
+  json<T>(schema: SchemaLike<T>): Promise<T>;
+  /** Declare the canonical endpoint this request maps to (chainable). */
+  track(pattern: string): ValidatingHttpResponsePromise;
+}
+
+/**
+ * The HTTP client returned by `configure()`. A regular {@link HttpClient} whose
+ * response promises additionally accept a schema in `.json(schema)`
+ * ({@link ValidatingHttpResponsePromise}). `.extend()` preserves the capability.
+ */
+export interface ConfiguredHttpClient extends HttpClient {
+  /** Make a request (generic). Same as ky(url, options). */
+  (
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** HTTP GET request */
+  get(
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** HTTP POST request */
+  post(
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** HTTP PUT request */
+  put(
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** HTTP PATCH request */
+  patch(
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** HTTP DELETE request */
+  delete(
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** HTTP HEAD request */
+  head(
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ): ValidatingHttpResponsePromise;
+
+  /** Create a new client with merged defaults — still schema-aware. */
+  extend(options: HttpRequestOptions): ConfiguredHttpClient;
 }
 
 // =============================================================================

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1780,6 +1780,29 @@ export interface HttpClient {
 }
 
 /**
+ * Runtime brand stamped on a response promise whose `.json()` accepts a schema.
+ *
+ * Both a type-level brand and a real property: `.json<T>()` (no arg) is
+ * STRUCTURALLY compatible with `.json<T>(schema)`, so without a nominal marker
+ * any plain {@link HttpResponsePromise} — e.g. `ctx.http.get(url)`, whose
+ * `.json(schema)` falls through to ky's Standard-Schema path and throws for a
+ * hand-rolled `SchemaLike` — would silently satisfy
+ * {@link ValidatingHttpResponsePromise}.
+ */
+export const SCHEMA_JSON_ATTACHED: unique symbol = Symbol.for(
+  "glubean.schemaJsonAttached",
+);
+
+/**
+ * Runtime brand stamped on the `configure()` HTTP client, for the same reason
+ * as {@link SCHEMA_JSON_ATTACHED}: it makes {@link ConfiguredHttpClient}
+ * nominal, so a bare {@link HttpClient} (`ctx.http`) cannot be assigned to it.
+ */
+export const CONFIGURED_HTTP_CLIENT: unique symbol = Symbol.for(
+  "glubean.configuredHttpClient",
+);
+
+/**
  * Response promise returned by the `configure()` HTTP client. Same surface as
  * {@link HttpResponsePromise} plus a schema-aware `.json(schema)` shortcut.
  *
@@ -1804,6 +1827,11 @@ export interface HttpClient {
  * ```
  */
 export interface ValidatingHttpResponsePromise extends HttpResponsePromise {
+  /**
+   * Nominal brand — set at runtime by the `configure()` client's decorator.
+   * Keeps a plain response promise from structurally satisfying this type.
+   */
+  readonly [SCHEMA_JSON_ATTACHED]: true;
   /** Parse response body as JSON (unvalidated — `T` is an author assertion). */
   json<T = unknown>(): Promise<T>;
   /** Parse response body as JSON, then validate it with `schema`. */
@@ -1818,6 +1846,14 @@ export interface ValidatingHttpResponsePromise extends HttpResponsePromise {
  * ({@link ValidatingHttpResponsePromise}). `.extend()` preserves the capability.
  */
 export interface ConfiguredHttpClient extends HttpClient {
+  /**
+   * Nominal brand — set at runtime by `configure()`. Without it a bare
+   * {@link HttpClient} would be assignable here (the no-arg `json<T>()` is
+   * structurally compatible with the schema overload) and its `.json(schema)`
+   * would blow up inside ky at run time.
+   */
+  readonly [CONFIGURED_HTTP_CLIENT]: true;
+
   /** Make a request (generic). Same as ky(url, options). */
   (
     url: string | URL | Request,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -504,6 +504,34 @@ export interface TestContext {
   warn(condition: boolean, message: string): void;
 
   /**
+   * Validate data against a schema with `severity: "fatal"` — returns `T`, not
+   * `T | undefined`.
+   *
+   * A fatal failure emits the failed assertion and then **throws** to abort the
+   * test, so the call only ever returns on success. The narrowed return type
+   * makes that truthful in the type system: no `!` or `as T` ceremony after the
+   * call.
+   *
+   * @param data The data to validate
+   * @param schema A schema implementing `safeParse` or `parse`
+   * @param label Human-readable label (pass `undefined` to omit)
+   * @param options Must include `severity: "fatal"` to select this overload
+   * @returns Parsed value (the failure path throws)
+   *
+   * @example Fatal — abort test on invalid response
+   * ```ts
+   * const user = ctx.validate(body, UserSchema, "response body", { severity: "fatal" });
+   * user.id; // typed as User — no non-null assertion needed
+   * ```
+   */
+  validate<T>(
+    data: unknown,
+    schema: SchemaLike<T>,
+    label: string | undefined,
+    options: ValidateOptions & { severity: "fatal" },
+  ): T;
+
+  /**
    * Validate data against a schema (Zod, Valibot, or any `SchemaLike<T>`).
    *
    * The runner prefers `safeParse` (no-throw) and falls back to `parse` (try/catch).
@@ -535,7 +563,8 @@ export interface TestContext {
    * @example Fatal — abort test on invalid response
    * ```ts
    * const user = ctx.validate(body, UserSchema, "response body", { severity: "fatal" });
-   * // Only reached if validation passed
+   * // Only reached if validation passed — the fatal overload returns `T`,
+   * // so `user` needs no non-null assertion.
    * ```
    */
   validate<T>(


### PR DESCRIPTION
Fixes #30
Fixes #31
Fixes #32

## What

Three independent fixes aligning what the type layer promises with what the runtime does:

1. **`ctx.validate` severity `"fatal"` narrows to `T`** — every implementation throws on a fatal failure, so the `T | undefined` signature forced non-null ceremony its own JSDoc contradicted. Review hardening went further than the overload: the no-parser path (a `jsonSchema`-only SchemaLike) in poll's quarantined ctx kept `ok = true`, and the sealed workflow node scope gated its fatal throw on liveness — both let a fatal validation pass silently. No parser now means failed validation everywhere, and the sealed-scope throw fires regardless of liveness (evidence stays gated — 'emit gated, throw always', the split its sibling `fail`/`skip` already document), with regression tests on all four implementation legs including a byte-identical engine-parity case.

2. **Hand-written HTTP examples are validated against their sibling schemas at contract construction** — advisory console warnings, once per site, four site kinds (`request.example`, `request.examples.*`, `expect.example`, `expect.examples.*`). The check runs on a `structuredClone` and only for plain-JSON shapes (proto === `Object.prototype`, default data descriptors, extensible, spec-fixed array `length` only) so a normalizing or prototype-/descriptor-sensitive schema can neither mutate the projection nor produce false warnings; site identity is an injective structured tuple, so dotted case keys can't collide dedup entries. Projection bytes and canonicalHash inputs are pinned untouched by test.

3. **`.json(schema)` on the `configure()` HTTP client** — decode + validate + return the schema-typed value in one call. The `json()` runtime lives in ky and the runner/engine patches, not this package, so the capability is honored exactly where the sdk owns the object: `ConfiguredHttpClient` / `ValidatingHttpResponsePromise` are branded with mandatory unique-symbol members set at decoration time — a plain `HttpClient` / `ctx.http` cannot structurally impersonate them and hit ky's standard-schema path at runtime. `ctx.http` parity is a follow-up.

## Verification

Full workspace `CI=1 pnpm -r build` / `CI=1 pnpm -r test` green after rebase onto the merged #34 (sdk 760, runner 1189, cli 627; the new typetest gate from #34 now enforces this PR's test-d files). Converged under the cross-host review gate: 5 rounds, foundation threshold (all findings including nits at zero) — round findings included two real runtime defects beyond the original scope (poll no-parser, orphaned-node fatal bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)